### PR TITLE
Fix duplicate ISA name in testnames

### DIFF
--- a/src/arc-validate/Program.fs
+++ b/src/arc-validate/Program.fs
@@ -28,10 +28,8 @@ let main argv =
         /// these tests MUST pass for an ARC to be considered for publishing
         let criticalTests =
             testList "Critical" [
-                testList "ARC" [    // maybe we don't even need this... what does it add semantically? We are always only testing the ARC...
-                    TestGeneration.Critical.Arc.FileSystem.generateArcFileSystemTests arcConfig
-                    TestGeneration.Critical.Arc.ISA.generateISATests arcConfig
-                ]
+                TestGeneration.Critical.Arc.FileSystem.generateArcFileSystemTests arcConfig
+                TestGeneration.Critical.Arc.ISA.generateISATests arcConfig
             ]
 
         let criticalTestResults =
@@ -43,8 +41,6 @@ let main argv =
             /// these tests SHOULD pass for an ARC to be considered of high quality
             let nonCriticalTests =
                 testList "Non-critical" [
-                    testList "ARC" []
-                    testList "ISA" []
                 ]
 
             let nonCriticalTestResults =

--- a/src/arc-validate/Program.fs
+++ b/src/arc-validate/Program.fs
@@ -28,10 +28,8 @@ let main argv =
         /// these tests MUST pass for an ARC to be considered for publishing
         let criticalTests =
             testList "Critical" [
-                testList "ARC" [
+                testList "ARC" [    // maybe we don't even need this... what does it add semantically? We are always only testing the ARC...
                     TestGeneration.Critical.Arc.FileSystem.generateArcFileSystemTests arcConfig
-                ]
-                testList "ISA" [
                     TestGeneration.Critical.Arc.ISA.generateISATests arcConfig
                 ]
             ]

--- a/tests/fixtures/xml/inveniotestarc/arc-validate-results.xml
+++ b/tests/fixtures/xml/inveniotestarc/arc-validate-results.xml
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <testsuites>
     <testsuite name="arc-validate">
-        <testcase name="[ Critical; ARC; Filesystem; arcFolder ]" time="0.002" />
-        <testcase name="[ Critical; ARC; Filesystem; InvestigationFile ]" time="0.002" />
-        <testcase name="[ Critical; ARC; Filesystem; StudiesFolder ]" time="0.002" />
-        <testcase name="[ Critical; ARC; Filesystem; AssaysFolder ]" time="0.002" />
-        <testcase name="[ Critical; ARC; Filesystem; Git; gitFolder ]" time="0.002" />
-        <testcase name="[ Critical; ISA; ISA; Semantic; Investigation; Contacts ]" time="0.002" />
-        <testcase name="[ Critical; ISA; ISA; Semantic; Investigation; Person; Person1 ]" time="0.001" />
-        <testcase name="[ Critical; ISA; ISA; Semantic; Investigation; Person; Person2 ]" time="0.001" />
-        <testcase name="[ Critical; ISA; ISA; Semantic; Investigation; Person; Person3 ]" time="0.001" />
-        <testcase name="[ Critical; ISA; ISA; Semantic; Investigation; Person; Person4 ]" time="0.001" />
+        <testcase name="[ Critical; Filesystem; arcFolder ]" time="0.002" />
+        <testcase name="[ Critical; Filesystem; InvestigationFile ]" time="0.002" />
+        <testcase name="[ Critical; Filesystem; StudiesFolder ]" time="0.002" />
+        <testcase name="[ Critical; Filesystem; AssaysFolder ]" time="0.002" />
+        <testcase name="[ Critical; Filesystem; Git; gitFolder ]" time="0.002" />
+        <testcase name="[ Critical; ISA; Semantic; Investigation; Contacts ]" time="0.002" />
+        <testcase name="[ Critical; ISA; Semantic; Investigation; Person; Person1 ]" time="0.001" />
+        <testcase name="[ Critical; ISA; Semantic; Investigation; Person; Person2 ]" time="0.001" />
+        <testcase name="[ Critical; ISA; Semantic; Investigation; Person; Person3 ]" time="0.001" />
+        <testcase name="[ Critical; ISA; Semantic; Investigation; Person; Person4 ]" time="0.001" />
     </testsuite>
 </testsuites>


### PR DESCRIPTION
- Naming in testnames changed
  - Duplicate ISA nesting removed
    - Fixes #17
  - ARC as second to top level name is obsolete and maybe even confusing (we don't test any other thing than ARCs)