### PR TITLE
Feature: fill tokens

### DIFF
--- a/arc-validate.sln
+++ b/arc-validate.sln
@@ -83,7 +83,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "demo_notebooks", "demo_note
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "qcPackage_prototypes", "qcPackage_prototypes", "{9B3B6E39-DB2F-4A91-944B-EFAAD961FCE7}"
 	ProjectSection(SolutionItems) = preProject
-		invenio_prototype_v0.1.0.fsx = invenio_prototype_v0.1.0.fsx
+		playgrounds\qcPackage_prototypes\invenio_prototype_v0.1.0.fsx = playgrounds\qcPackage_prototypes\invenio_prototype_v0.1.0.fsx
 	EndProjectSection
 EndProject
 Global

--- a/arc-validate.sln
+++ b/arc-validate.sln
@@ -81,6 +81,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "demo_notebooks", "demo_note
 		playgrounds\demo_notebooks\demo_ARCGraph.ipynb = playgrounds\demo_notebooks\demo_ARCGraph.ipynb
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "qcPackage_prototypes", "qcPackage_prototypes", "{9B3B6E39-DB2F-4A91-944B-EFAAD961FCE7}"
+	ProjectSection(SolutionItems) = preProject
+		invenio_prototype_v0.1.0.fsx = invenio_prototype_v0.1.0.fsx
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -130,6 +135,7 @@ Global
 		{46EA4BDB-095A-4369-AD7E-07E702CD3E38} = {5C204780-A94B-46A2-B768-B12C7D81DDFC}
 		{02699157-EFC4-4E1A-94CC-B9825E2D1CB8} = {7994D526-5B21-4EBD-9CCB-EFA04EE303CF}
 		{A83F65C9-925E-437C-A457-EF8B9C6B154D} = {B3F07465-2108-4C43-843A-9F503044FDB7}
+		{9B3B6E39-DB2F-4A91-944B-EFAAD961FCE7} = {7994D526-5B21-4EBD-9CCB-EFA04EE303CF}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FF9C2722-38D9-48C4-8095-4726C56E92DE}

--- a/arc-validate.sln
+++ b/arc-validate.sln
@@ -13,8 +13,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "sln", "sln", "{B3F07465-210
 		ErrorClassOntology.obo = ErrorClassOntology.obo
 		global.json = global.json
 		README.md = README.md
-		RELEASE_NOTES.md = RELEASE_NOTES.md
 		TestOntology.obo = TestOntology.obo
+		playgrounds\workingGraph.md = playgrounds\workingGraph.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{6275F297-567B-421B-B055-4F88B2785765}"
@@ -55,7 +55,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "playgrounds", "playgrounds"
 		playgrounds\graphModelIOTest.fsx = playgrounds\graphModelIOTest.fsx
 		playgrounds\graphoscopePlayground.fsx = playgrounds\graphoscopePlayground.fsx
 		playgrounds\playground.fsx = playgrounds\playground.fsx
-		playgrounds\workingGraph.md = playgrounds\workingGraph.md
 	EndProjectSection
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "ARCValidationPackages", "src\ARCValidationPackages\ARCValidationPackages.fsproj", "{CF14C74E-20D2-4EC9-B11E-357BFD1244CB}"
@@ -70,6 +69,7 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "ARCExpect.Tests", "tests\AR
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "arcGraph_prototypes", "arcGraph_prototypes", "{02699157-EFC4-4E1A-94CC-B9825E2D1CB8}"
 	ProjectSection(SolutionItems) = preProject
+		carepaket.fsx = carepaket.fsx
 		playgrounds\arcGraph_playgrounds\prototype_v0.1.0.fsx = playgrounds\arcGraph_playgrounds\prototype_v0.1.0.fsx
 		playgrounds\arcGraph_playgrounds\prototype_v0.1.1.fsx = playgrounds\arcGraph_playgrounds\prototype_v0.1.1.fsx
 		playgrounds\arcGraph_playgrounds\prototype_v0.2.0.fsx = playgrounds\arcGraph_playgrounds\prototype_v0.2.0.fsx
@@ -77,9 +77,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "arcGraph_prototypes", "arcG
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "demo_notebooks", "demo_notebooks", "{A83F65C9-925E-437C-A457-EF8B9C6B154D}"
-	ProjectSection(SolutionItems) = preProject
-		playgrounds\demo_notebooks\demo_ARCGraph.ipynb = playgrounds\demo_notebooks\demo_ARCGraph.ipynb
-	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "qcPackage_prototypes", "qcPackage_prototypes", "{9B3B6E39-DB2F-4A91-944B-EFAAD961FCE7}"
 	ProjectSection(SolutionItems) = preProject

--- a/invenio_prototype_v0.1.0.fsx
+++ b/invenio_prototype_v0.1.0.fsx
@@ -1,0 +1,2 @@
+#r "nuget: ARCExpect"
+

--- a/invenio_prototype_v0.1.0.fsx
+++ b/invenio_prototype_v0.1.0.fsx
@@ -1,2 +1,0 @@
-#r "nuget: ARCExpect"
-

--- a/playgrounds/qcPackage_prototypes/invenio_prototype_v0.1.0.fsx
+++ b/playgrounds/qcPackage_prototypes/invenio_prototype_v0.1.0.fsx
@@ -118,6 +118,15 @@ let mock =
     |> Seq.map (fun cvp -> cvp :> IParam)
 
 let output = fillTokenList Terms.InvestigationMetadata.ontology mock 
+Seq.head output
+Seq.item 1 output
+
+let actual = output
+let act3 = actual |> Seq.tryItem 1 |> Option.bind (Seq.tryFind (fun t -> t |> Seq.exists (fun (t1,t2) -> t1 = ("Investigation Title", 1))))
+let act4 = 
+    Option.defaultValue Seq.empty act3 
+    |> Seq.map (fun (t1,t2) -> t2.Value |> ParamValue.getValueAsString) 
+    |> Seq.tryItem 2
 
 // End of Helper Functions:
 // >>>>>>>>>>>>>>>>>>>>>>>>

--- a/playgrounds/qcPackage_prototypes/invenio_prototype_v0.1.0.fsx
+++ b/playgrounds/qcPackage_prototypes/invenio_prototype_v0.1.0.fsx
@@ -1,5 +1,5 @@
-#I "../../src/arc-validate/bin/Debug/net6.0"
-#I "../../src/arc-validate/bin/Release/net6.0"
+#I "../../src/arc-validate/bin/Debug/net8.0"
+#I "../../src/arc-validate/bin/Release/net8.0"
 #r "ARCExpect.dll"
 #r "ARCTokenization.dll"
 #r "ControlledVocabulary.dll"
@@ -118,7 +118,7 @@ let invesCases = testList "" [
             fun ip ->
                 let thisTest = test "is not empty"
                 thisTest.Run (fun _ ->
-                    try ip :?> CvParam |> ARCExpect.ByValue.notEmpty
+                    try ip :?> CvParam |> Validate.ByValue.notEmpty
                     with :? System.InvalidCastException -> ()
                 )
         )
@@ -131,7 +131,7 @@ let invesCases = testList "" [
             fun ip ->
                 let thisTest = test "is not empty"
                 thisTest.Run (fun _ ->
-                    try ip :?> CvParam |> ARCExpect.ByValue.notEmpty
+                    try ip :?> CvParam |> Validate.ByValue.notEmpty
                     with :? System.InvalidCastException -> ()
                 )
         )
@@ -144,7 +144,7 @@ let invesCases = testList "" [
             fun ip ->
                 let thisTest = test "is not empty"
                 thisTest.Run (fun _ ->
-                    try ip :?> CvParam |> ARCExpect.ByValue.notEmpty
+                    try ip :?> CvParam |> Validate.ByValue.notEmpty
                     with :? System.InvalidCastException -> ()
                 )
         )
@@ -157,7 +157,7 @@ let invesCases = testList "" [
             fun ip ->
                 let thisTest = test "is not empty"
                 thisTest.Run (fun _ ->
-                    try ip :?> CvParam |> ARCExpect.ByValue.notEmpty
+                    try ip :?> CvParam |> Validate.ByValue.notEmpty
                     with :? System.InvalidCastException -> ()
                 )
         )
@@ -170,7 +170,7 @@ let invesCases = testList "" [
             fun ip ->
                 let thisTest = test "is not empty"
                 thisTest.Run (fun _ ->
-                    try ip :?> CvParam |> ARCExpect.Valid.email
+                    try ip :?> CvParam |> Validate.email
                     with :? System.InvalidCastException -> ()
                 )
         )

--- a/playgrounds/qcPackage_prototypes/invenio_prototype_v0.1.0.fsx
+++ b/playgrounds/qcPackage_prototypes/invenio_prototype_v0.1.0.fsx
@@ -1,0 +1,253 @@
+#I "../../src/arc-validate/bin/Debug/net6.0"
+#I "../../src/arc-validate/bin/Release/net6.0"
+#r "ARCExpect.dll"
+#r "ARCTokenization.dll"
+#r "ControlledVocabulary.dll"
+#r "arc-validate.dll"
+#r "Anybadge.NET.dll"
+#r "Expecto.dll"
+#r "FsOboParser.dll"
+
+//#r "nuget: ARCExpect"
+#r "nuget: Anybadge.NET"
+#r "nuget: FSharpAux"
+#r "nuget: Graphoscope"
+
+open ARCExpect
+open ARCTokenization
+open ARCTokenization.StructuralOntology
+open ControlledVocabulary
+open Expecto
+open Expecto.Tests
+open AnyBadge.NET
+open ARCValidate
+open FSharpAux
+open Graphoscope
+
+open System.IO
+
+
+// input:
+
+let arcDir = @"C:\Repos\git.nfdi4plants.org\ArcPrototype"
+let outDir = arcDir
+
+// Tokenization:
+
+// <<<<<<<<<<<<<<<<<
+// Helper Functions:
+
+let parseIsaMetadataSheetFromCvp isaFileName isaMdsParsingF absFileTokens =
+    absFileTokens
+    |> Seq.choose (
+        fun cvp ->
+            let cvpStr = Param.getValueAsString cvp
+            //printfn $"cvpStr: {cvpStr}"
+            if String.contains isaFileName cvpStr then
+                Some (isaMdsParsingF cvpStr)
+            else None
+    )
+
+let parseInvestigationMetadataSheetFromCvp absFileTokens =
+    parseIsaMetadataSheetFromCvp "isa.investigation.xlsx" ARCTokenization.Investigation.parseMetadataSheetFromFile absFileTokens
+
+let parseStudyMetadataSheetFromCvp absFileTokens =
+    parseIsaMetadataSheetFromCvp "isa.study.xlsx" ARCTokenization.Study.parseMetadataSheetfromFile absFileTokens
+
+let parseAssayMetadataSheetFromCvp absFileTokens =
+    parseIsaMetadataSheetFromCvp "isa.assay.xlsx" ARCTokenization.Assay.parseMetadataSheetFromFile absFileTokens
+
+let tryParseIsaMetadataSheetFromCvp isaFileName isaMdsParsingF absFileTokens =
+    absFileTokens
+    |> Seq.choose (
+        fun cvp ->
+            let cvpStr = Param.getValueAsString cvp
+            //printfn $"cvpStr: {cvpStr}"
+            if String.contains isaFileName cvpStr then
+                try Some (isaMdsParsingF cvpStr)
+                with _ -> None
+            else None
+    )
+
+let tryParseInvestigationMetadataSheetFromCvp absFileTokens =
+    try tryParseIsaMetadataSheetFromCvp "isa.investigation.xlsx" ARCTokenization.Investigation.parseMetadataSheetFromFile absFileTokens 
+        |> Seq.concat
+    with _ -> Seq.empty
+
+let tryParseStudyMetadataSheetFromCvp absFileTokens =
+    tryParseIsaMetadataSheetFromCvp "isa.study.xlsx" ARCTokenization.Study.parseMetadataSheetfromFile absFileTokens
+
+let tryParseAssayMetadataSheetFromCvp absFileTokens =
+    tryParseIsaMetadataSheetFromCvp "isa.assay.xlsx" ARCTokenization.Assay.parseMetadataSheetFromFile absFileTokens
+
+let fillTokenList onto tokens =
+    let ontoGraph = OboGraph.ontologyToFGraphByName onto
+    let ipsAdded = ARCGraph.addMissingTerms onto tokens
+    let partitionedIps = Seq.groupWhen (ARCGraph.isHeader ontoGraph) ipsAdded
+    let partitionallyFilledIps = partitionedIps |> Seq.map (ARCGraph.addMissingTermsInGroup ontoGraph)
+    let groupedIps = partitionallyFilledIps |> Seq.map ARCGraph.groupTerms
+    let matchedIps = groupedIps |> Seq.map (ARCGraph.matchTerms onto)
+    let subgraphs = Seq.map (ARCGraph.constructIntermediateMetadataSubgraph ontoGraph) matchedIps
+    let filledSubgraphs = Seq.map (fst >> ARCGraph.addEmptyIpsToNodeData) subgraphs
+    let splitSubgraphs = Seq.map ARCGraph.splitMetadataSubgraph filledSubgraphs
+    Seq.map ARCGraph.metadataSubgraphToList splitSubgraphs
+
+// End of Helper Functions:
+// >>>>>>>>>>>>>>>>>>>>>>>>
+
+let fsTokensRelDirs = ARCTokenization.FileSystem.parseRelativeDirectoryPaths arcDir
+let fsTokensAbsDirs = ARCTokenization.FileSystem.parseAbsoluteDirectoryPaths arcDir
+let fsTokensRelFils = ARCTokenization.FileSystem.parseAbsoluteFilePaths arcDir
+let fsTokensAbsFils = ARCTokenization.FileSystem.parseAbsoluteFilePaths arcDir
+
+let invesTokens = tryParseInvestigationMetadataSheetFromCvp fsTokensAbsFils
+let studyTokens = tryParseStudyMetadataSheetFromCvp fsTokensAbsFils
+let assayTokens = tryParseAssayMetadataSheetFromCvp fsTokensAbsFils
+
+let filledInvesTokens = fillTokenList Terms.InvestigationMetadata.ontology invesTokens
+let filledStudyTokens = studyTokens |> Seq.map (fillTokenList Terms.StudyMetadata.ontology)
+let filledAssayTokens = assayTokens |> Seq.map (fillTokenList Terms.AssayMetadata.ontology)
+
+// Validation cases:
+
+let invesCases = testList "" [
+    testList INVMSO.``Investigation Metadata``.``INVESTIGATION CONTACTS``.``Investigation Person First Name``.Name (
+        invesTokens 
+        |> Seq.filter (fun ip -> ip.Name = "Investigation Person First Name")
+        |> Seq.map (
+            fun ip ->
+                let thisTest = test "is not empty"
+                thisTest.Run (fun _ ->
+                    try ip :?> CvParam |> ARCExpect.ByValue.notEmpty
+                    with :? System.InvalidCastException -> ()
+                )
+        )
+        |> Seq.toList
+    )
+    testList INVMSO.``Investigation Metadata``.``INVESTIGATION CONTACTS``.``Investigation Person Last Name``.Name (
+        invesTokens 
+        |> Seq.filter (fun ip -> ip.Name = "Investigation Person Last Name")
+        |> Seq.map (
+            fun ip ->
+                let thisTest = test "is not empty"
+                thisTest.Run (fun _ ->
+                    try ip :?> CvParam |> ARCExpect.ByValue.notEmpty
+                    with :? System.InvalidCastException -> ()
+                )
+        )
+        |> Seq.toList
+    )
+    testList INVMSO.``Investigation Metadata``.``INVESTIGATION CONTACTS``.``Investigation Person Last Name``.Name (
+        invesTokens 
+        |> Seq.filter (fun ip -> ip.Name = "Investigation Person Last Name")
+        |> Seq.map (
+            fun ip ->
+                let thisTest = test "is not empty"
+                thisTest.Run (fun _ ->
+                    try ip :?> CvParam |> ARCExpect.ByValue.notEmpty
+                    with :? System.InvalidCastException -> ()
+                )
+        )
+        |> Seq.toList
+    )
+    testList INVMSO.``Investigation Metadata``.``INVESTIGATION CONTACTS``.``Investigation Person Affiliation``.Name (
+        invesTokens 
+        |> Seq.filter (fun ip -> ip.Name = "Investigation Person Affiliation")
+        |> Seq.map (
+            fun ip ->
+                let thisTest = test "is not empty"
+                thisTest.Run (fun _ ->
+                    try ip :?> CvParam |> ARCExpect.ByValue.notEmpty
+                    with :? System.InvalidCastException -> ()
+                )
+        )
+        |> Seq.toList
+    )
+    testList INVMSO.``Investigation Metadata``.``INVESTIGATION CONTACTS``.``Investigation Person Email``.Name (
+        invesTokens 
+        |> Seq.filter (fun ip -> ip.Name = "Investigation Person Email")
+        |> Seq.map (
+            fun ip ->
+                let thisTest = test "is not empty"
+                thisTest.Run (fun _ ->
+                    try ip :?> CvParam |> ARCExpect.Valid.email
+                    with :? System.InvalidCastException -> ()
+                )
+        )
+        |> Seq.toList
+    )
+]
+
+
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+// Temporarily copypasted vom ValidateAPI.fs:
+
+let validate (verbose: bool) arcDir outDir =
+
+    let root = arcDir
+    //    args.TryGetResult(ARC_Directory)
+    //    |> Option.defaultValue (System.Environment.GetEnvironmentVariable("ARC_PATH")) // default to ARC_PATH if argument is not provided
+    //    |> fun s -> if System.String.IsNullOrWhiteSpace(s) then System.Environment.CurrentDirectory else s // default to ./ if ARC_PATH is not set
+    //    |> Path.GetFullPath
+    //    |> fun p -> p.Replace("\\","/")
+    //    |> fun p -> if not (p.EndsWith("/")) then p + "/" else p // ensure path ends with a slash
+
+    let outPath = outDir
+        //args.TryGetResult(Out_Directory)
+        //|> Option.defaultValue root
+
+    /// these tests MUST pass for an ARC to be considered for publishing
+    let criticalTests =
+        testList "Critical" [
+            invesCases
+        ]
+
+    let criticalTestResults =
+        criticalTests
+        |> performTest
+
+    if criticalTestResults.failed |> List.isEmpty && criticalTestResults.errored |> List.isEmpty then // if no critical tests failed or errored
+            
+        /// these tests SHOULD pass for an ARC to be considered of high quality
+        let nonCriticalTests =
+            testList "Non-critical" [
+                //TestGeneration.NonCritical.ARC.ISA.generateISATests investigationTokens   // atm. not wanted
+            ]
+
+        let nonCriticalTestResults =
+            nonCriticalTests
+            |> performTest
+
+        let combinedTestResults = 
+            [criticalTestResults; nonCriticalTestResults] 
+            |> combineTestRunSummaries // aggregate critical and non-critical test results
+
+        let badge = 
+            combinedTestResults
+            |> BadgeCreation.createSuccessBadge "ARC quality"
+            
+        badge.WriteBadge(Path.Combine(outPath, "arc-quality.svg"))
+
+        combinedTestResults
+        |> writeJUnitSummary verbose (Path.Combine(outPath, "arc-validate-results.xml")) // write the combined result to a single file
+
+        ExitCode.Success // critical tests passed, non-critical tests have been performed. Success!
+
+    else // one or more critical tests failed or errored.
+
+        let badge = 
+            criticalTestResults
+            |> BadgeCreation.createCriticalFailBadge "ARC quality"
+            
+        badge.WriteBadge(Path.Combine(outPath, "arc-quality.svg"))
+
+        criticalTestResults
+        |> Expecto.writeJUnitSummary verbose (Path.Combine(outPath, "arc-validate-results.xml"))
+
+        ExitCode.CriticalTestFailure
+
+// End of Copypaste
+// >>>>>>>>>>>>>>>>
+
+
+validate true @"C:\Repos\git.nfdi4plants.org\ArcPrototype" @"C:\Repos\git.nfdi4plants.org\ArcPrototype"

--- a/playgrounds/qcPackage_prototypes/invenio_prototype_v0.1.0.fsx
+++ b/playgrounds/qcPackage_prototypes/invenio_prototype_v0.1.0.fsx
@@ -96,6 +96,29 @@ let fillTokenList onto tokens =
     Seq.map ARCGraph.metadataSubgraphToList splitSubgraphs
 // --->
 
+let mock =
+    ARCTokenization.ARCMock.InvestigationMetadataTokens(
+        Investigation_Identifier = ["iid"],
+        Investigation_Title = ["ititle"],
+        Investigation_Description = ["idesc"],
+        Investigation_Person_Last_Name = ["Maus"; "Keider"; "müller"; ""; "oih"],
+        Investigation_Person_First_Name = ["Oliver"; ""; "andreas";],
+        Investigation_Person_Mid_Initials = ["L. I."; "C."],
+        Investigation_Person_Email = ["maus@nfdi4plants.org"],
+        Investigation_Person_Affiliation = [""; "Affe"],
+        Study_Identifier = ["sid"],
+        Study_Title = ["stitle"],
+        Study_Description = ["sdesc"],
+        Study_File_Name = [@"sid\isa.study.xlsx"],
+        Study_Assay_File_Name = [@"aid\isa.assay.xlsx"; @"aid2\isa.assay.xlsx"],
+        Study_Person_Last_Name = ["weil"],
+        Study_Person_First_Name = [""; "lukas"]
+    )
+    |> List.concat // use flat list
+    |> Seq.map (fun cvp -> cvp :> IParam)
+
+let output = fillTokenList Terms.InvestigationMetadata.ontology mock 
+
 // End of Helper Functions:
 // >>>>>>>>>>>>>>>>>>>>>>>>
 

--- a/src/ARCExpect/ARCExpect.fsproj
+++ b/src/ARCExpect/ARCExpect.fsproj
@@ -32,7 +32,7 @@
     <PackageReference Include="FSharpAux" Version="[2.0.0]" />
     <PackageReference Include="FsSpreadsheet" Version="[4.1.0]" />
     <PackageReference Include="FsSpreadsheet.ExcelIO" Version="[4.1.0]" />
-    <PackageReference Include="ARCTokenization" Version="[1.2.0]" />
+    <PackageReference Include="ARCTokenization" Version="[1.3.0]" />
     <PackageReference Include="Graphoscope" Version="[0.6.0-preview.1]" />
     <PackageReference Include="FsOboParser" Version="[0.3.0]" />
     <PackageReference Include="Cytoscape.NET" Version="[0.2.0]" />

--- a/src/ARCExpect/ARCExpect.fsproj
+++ b/src/ARCExpect/ARCExpect.fsproj
@@ -32,7 +32,7 @@
     <PackageReference Include="FSharpAux" Version="[2.0.0]" />
     <PackageReference Include="FsSpreadsheet" Version="[4.1.0]" />
     <PackageReference Include="FsSpreadsheet.ExcelIO" Version="[4.1.0]" />
-    <PackageReference Include="ARCTokenization" Version="[1.4.0]" />
+    <PackageReference Include="ARCTokenization" Version="[2.0.0]" />
     <PackageReference Include="Graphoscope" Version="[0.6.0-preview.1]" />
     <PackageReference Include="FsOboParser" Version="[0.3.0]" />
     <PackageReference Include="Cytoscape.NET" Version="[0.2.0]" />

--- a/src/ARCExpect/ARCExpect.fsproj
+++ b/src/ARCExpect/ARCExpect.fsproj
@@ -32,7 +32,7 @@
     <PackageReference Include="FSharpAux" Version="[2.0.0]" />
     <PackageReference Include="FsSpreadsheet" Version="[4.1.0]" />
     <PackageReference Include="FsSpreadsheet.ExcelIO" Version="[4.1.0]" />
-    <PackageReference Include="ARCTokenization" Version="[1.3.0]" />
+    <PackageReference Include="ARCTokenization" Version="[1.4.0]" />
     <PackageReference Include="Graphoscope" Version="[0.6.0-preview.1]" />
     <PackageReference Include="FsOboParser" Version="[0.3.0]" />
     <PackageReference Include="Cytoscape.NET" Version="[0.2.0]" />

--- a/src/ARCExpect/ARCGraph.fs
+++ b/src/ARCExpect/ARCGraph.fs
@@ -16,9 +16,9 @@ module ARCGraph =
 
     /// Representation of the familiarity of a CvParam's CvTerm. If the CvTerm is known in, e.g., an ontology, use KnownTerm, else use UnknownTerm. ObsoleteTerm is for deprecated terms (i.e., OboTerm with `is_obsolete` = `true`).
     type TermFamiliarity =
-        | KnownTerm of IParam
-        | UnknownTerm of IParam
-        | ObsoleteTerm of IParam
+        | KnownTerm     of IParam
+        | UnknownTerm   of IParam
+        | ObsoleteTerm  of IParam
         | MisplacedTerm of IParam
 
     /// Takes a list of CvParams and returns the ArcGraph as an FGraph consisting of Nodes only.

--- a/src/ARCExpect/ARCGraph.fs
+++ b/src/ARCExpect/ARCGraph.fs
@@ -138,6 +138,7 @@ module ARCGraph =
     /// Returns all terms that are present in the given ontology but don't occur in the given CvParam list as CvParams.
     let getMissingTerms (onto : OboOntology) (ips : IParam seq) =
         onto.Terms
+        |> Seq.skip 1
         |> Seq.choose (
             fun o -> 
                 if o.IsObsolete then None

--- a/src/ARCExpect/ARCGraph.fs
+++ b/src/ARCExpect/ARCGraph.fs
@@ -516,6 +516,19 @@ module ARCGraph =
             )
         )
 
+    /// Takes a structural ontology and a seq of IParams, fills in all missing IParams, and returns the IParam seq but grouped by term name (most inner seq) and divided into sections (middle seq).
+    let fillTokenList (onto : OboOntology) (tokens : IParam seq) =
+        let ontoGraph = OboGraph.ontologyToFGraphByName onto
+        let ipsAdded = addMissingTerms onto tokens
+        let partitionedIps = Seq.groupWhen (isHeader ontoGraph) ipsAdded
+        let partitionallyFilledIps = partitionedIps |> Seq.map (addMissingTermsInGroup ontoGraph)
+        let groupedIps = partitionallyFilledIps |> Seq.map groupTerms
+        let matchedIps = groupedIps |> Seq.map (matchTerms onto)
+        let subgraphs = Seq.map (constructIntermediateMetadataSubgraph ontoGraph) matchedIps
+        let filledSubgraphs = Seq.map (fst >> addEmptyIpsToNodeData) subgraphs
+        let splitSubgraphs = Seq.map splitMetadataSubgraph filledSubgraphs
+        Seq.map metadataSubgraphToList splitSubgraphs
+
 
     /// Functions for visualizing ARC FGraphs.
     module Visualization =

--- a/src/ARCExpect/packages.lock.json
+++ b/src/ARCExpect/packages.lock.json
@@ -4,9 +4,9 @@
     ".NETStandard,Version=v2.0": {
       "ARCTokenization": {
         "type": "Direct",
-        "requested": "[1.4.0, 1.4.0]",
-        "resolved": "1.4.0",
-        "contentHash": "lziUUPqLNXNB1atEg4jgShaFdwp5mWaM56xIvnobmkVFG3msbuzD1BJ2+6fWwF4QjYx0Ylkv9v9UqW4hk5bDfA==",
+        "requested": "[2.0.0, 2.0.0]",
+        "resolved": "2.0.0",
+        "contentHash": "t0NUB1/MIcjHwy+qZ3yh1C33o40sIN5wEo2zoUHqnqTOjSaVB5zl1fn12EE+9hHGHPNirt581lisR5Guu0X4bQ==",
         "dependencies": {
           "ControlledVocabulary": "[1.0.0, 2.0.0)",
           "FSharp.Core": "8.0.100",

--- a/src/ARCExpect/packages.lock.json
+++ b/src/ARCExpect/packages.lock.json
@@ -4,9 +4,9 @@
     ".NETStandard,Version=v2.0": {
       "ARCTokenization": {
         "type": "Direct",
-        "requested": "[1.3.0, 1.3.0]",
-        "resolved": "1.3.0",
-        "contentHash": "9tWY0tpgoCxzXE7ASoOlt56IMyxUnnv8WBcpL0pOyIkFphutbbSSh3njyEocajDAbYRD9m3m+l+NXAT+f3QYKw==",
+        "requested": "[1.4.0, 1.4.0]",
+        "resolved": "1.4.0",
+        "contentHash": "lziUUPqLNXNB1atEg4jgShaFdwp5mWaM56xIvnobmkVFG3msbuzD1BJ2+6fWwF4QjYx0Ylkv9v9UqW4hk5bDfA==",
         "dependencies": {
           "ControlledVocabulary": "[1.0.0, 2.0.0)",
           "FSharp.Core": "8.0.100",

--- a/src/ARCExpect/packages.lock.json
+++ b/src/ARCExpect/packages.lock.json
@@ -4,12 +4,12 @@
     ".NETStandard,Version=v2.0": {
       "ARCTokenization": {
         "type": "Direct",
-        "requested": "[1.2.0, 1.2.0]",
-        "resolved": "1.2.0",
-        "contentHash": "0pVnsXxTa1Mu0lJHyYnLeA+yVZGg4VWxtN3pI1OM4XnbeVLTc/2qpkC0PB2WBRcnHACzd53T4KwoU1Xno0empQ==",
+        "requested": "[1.3.0, 1.3.0]",
+        "resolved": "1.3.0",
+        "contentHash": "9tWY0tpgoCxzXE7ASoOlt56IMyxUnnv8WBcpL0pOyIkFphutbbSSh3njyEocajDAbYRD9m3m+l+NXAT+f3QYKw==",
         "dependencies": {
           "ControlledVocabulary": "[1.0.0, 2.0.0)",
-          "FSharp.Core": "6.0.7",
+          "FSharp.Core": "8.0.100",
           "FSharpAux.Core": "[2.0.0]",
           "FsOboParser": "[0.3.0]",
           "FsSpreadsheet": "[4.1.0]",

--- a/src/arc-validate/packages.lock.json
+++ b/src/arc-validate/packages.lock.json
@@ -40,8 +40,8 @@
       },
       "ARCTokenization": {
         "type": "Transitive",
-        "resolved": "1.3.0",
-        "contentHash": "9tWY0tpgoCxzXE7ASoOlt56IMyxUnnv8WBcpL0pOyIkFphutbbSSh3njyEocajDAbYRD9m3m+l+NXAT+f3QYKw==",
+        "resolved": "1.4.0",
+        "contentHash": "lziUUPqLNXNB1atEg4jgShaFdwp5mWaM56xIvnobmkVFG3msbuzD1BJ2+6fWwF4QjYx0Ylkv9v9UqW4hk5bDfA==",
         "dependencies": {
           "ControlledVocabulary": "[1.0.0, 2.0.0)",
           "FSharp.Core": "8.0.100",
@@ -921,7 +921,7 @@
       "arcexpect": {
         "type": "Project",
         "dependencies": {
-          "ARCTokenization": "[1.3.0, 1.3.0]",
+          "ARCTokenization": "[1.4.0, 1.4.0]",
           "Cytoscape.NET": "[0.2.0, 0.2.0]",
           "Expecto": "[9.0.4, 9.0.4]",
           "FSharp.Core": "[8.0.100, )",

--- a/src/arc-validate/packages.lock.json
+++ b/src/arc-validate/packages.lock.json
@@ -40,8 +40,8 @@
       },
       "ARCTokenization": {
         "type": "Transitive",
-        "resolved": "1.4.0",
-        "contentHash": "lziUUPqLNXNB1atEg4jgShaFdwp5mWaM56xIvnobmkVFG3msbuzD1BJ2+6fWwF4QjYx0Ylkv9v9UqW4hk5bDfA==",
+        "resolved": "2.0.0",
+        "contentHash": "t0NUB1/MIcjHwy+qZ3yh1C33o40sIN5wEo2zoUHqnqTOjSaVB5zl1fn12EE+9hHGHPNirt581lisR5Guu0X4bQ==",
         "dependencies": {
           "ControlledVocabulary": "[1.0.0, 2.0.0)",
           "FSharp.Core": "8.0.100",
@@ -921,7 +921,7 @@
       "arcexpect": {
         "type": "Project",
         "dependencies": {
-          "ARCTokenization": "[1.4.0, 1.4.0]",
+          "ARCTokenization": "[2.0.0, 2.0.0]",
           "Cytoscape.NET": "[0.2.0, 0.2.0]",
           "Expecto": "[9.0.4, 9.0.4]",
           "FSharp.Core": "[8.0.100, )",

--- a/src/arc-validate/packages.lock.json
+++ b/src/arc-validate/packages.lock.json
@@ -40,11 +40,11 @@
       },
       "ARCTokenization": {
         "type": "Transitive",
-        "resolved": "1.2.0",
-        "contentHash": "0pVnsXxTa1Mu0lJHyYnLeA+yVZGg4VWxtN3pI1OM4XnbeVLTc/2qpkC0PB2WBRcnHACzd53T4KwoU1Xno0empQ==",
+        "resolved": "1.3.0",
+        "contentHash": "9tWY0tpgoCxzXE7ASoOlt56IMyxUnnv8WBcpL0pOyIkFphutbbSSh3njyEocajDAbYRD9m3m+l+NXAT+f3QYKw==",
         "dependencies": {
           "ControlledVocabulary": "[1.0.0, 2.0.0)",
-          "FSharp.Core": "6.0.7",
+          "FSharp.Core": "8.0.100",
           "FSharpAux.Core": "[2.0.0]",
           "FsOboParser": "[0.3.0]",
           "FsSpreadsheet": "[4.1.0]",
@@ -921,7 +921,7 @@
       "arcexpect": {
         "type": "Project",
         "dependencies": {
-          "ARCTokenization": "[1.2.0, 1.2.0]",
+          "ARCTokenization": "[1.3.0, 1.3.0]",
           "Cytoscape.NET": "[0.2.0, 0.2.0]",
           "Expecto": "[9.0.4, 9.0.4]",
           "FSharp.Core": "[8.0.100, )",

--- a/tests/ARCExpect.Tests/ARCExpect.Tests.fsproj
+++ b/tests/ARCExpect.Tests/ARCExpect.Tests.fsproj
@@ -17,6 +17,7 @@
     <Compile Include="CvParamExtensionsTest.fs" />
     <Compile Include="ParamCollectionTests.fs" />
     <Compile Include="ARCExpectTests.fs" />
+    <Compile Include="ARCGraphTests.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
 

--- a/tests/ARCExpect.Tests/ARCGraphTests.fs
+++ b/tests/ARCExpect.Tests/ARCGraphTests.fs
@@ -126,12 +126,12 @@ let ``fillTokenList tests`` =
 
         testCase "Assay" (fun _ ->
             let actual = ARCGraph.fillTokenList Terms.AssayMetadata.ontology mockAss
-            let act1 = actual |> Seq.tryItem 2 |> Option.bind (Seq.tryFind (fun t -> t |> Seq.exists (fun (t1,t2) -> t1 = ("Assay Filename", 0))))
+            let act1 = actual |> Seq.tryItem 0 |> Option.bind (Seq.tryFind (fun t -> t |> Seq.exists (fun (t1,t2) -> t1 = ("Assay File Name", 1))))
             Expect.isSome act1 "missing Assay Filename"
             let act2 = 
                 Option.defaultValue Seq.empty act1 
                 |> Seq.map (fun (t1,t2) -> t2.Value |> ParamValue.getValueAsString) 
-                |> Seq.tryItem 0
+                |> Seq.tryItem 8
                 |> Option.defaultValue ""
             let exp2 = @"measurement1\isa.assay.xlsx"
             Expect.equal act2 exp2 "wrong Assay Filename"

--- a/tests/ARCExpect.Tests/ARCGraphTests.fs
+++ b/tests/ARCExpect.Tests/ARCGraphTests.fs
@@ -1,0 +1,38 @@
+﻿module ARCGraphTests
+
+
+open ARCExpect
+open Expecto
+open ARCTokenization
+
+
+let mockInv = 
+    ARCMock.InvestigationMetadataTokens(
+        Investigation_Identifier = ["iid"],
+        Investigation_Title = ["ititle"],
+        Investigation_Description = ["idesc"],
+        Investigation_Person_Last_Name = ["Maus"; "Keider"; "müller"; ""; "oih"],
+        Investigation_Person_First_Name = ["Oliver"; ""; "andreas";],
+        Investigation_Person_Mid_Initials = ["L. I."; "C."],
+        Investigation_Person_Email = ["maus@nfdi4plants.org"],
+        Investigation_Person_Affiliation = [""; "Affe"],
+        Study_Identifier = ["sid"],
+        Study_Title = ["stitle"],
+        Study_Description = ["sdesc"],
+        Study_File_Name = [@"sid\isa.study.xlsx"],
+        Study_Assay_File_Name = [@"aid\isa.assay.xlsx"; @"aid2\isa.assay.xlsx"],
+        Study_Person_Last_Name = ["weil"],
+        Study_Person_First_Name = [""; "lukas"]
+    )
+    |> List.concat // use flat list
+
+
+
+[<Tests>]
+let ``fillTokenList tests`` =
+    testCase "returns correct output seq" (fun _ ->
+        let actual = ARCGraph.fillTokenList Terms.InvestigationMetadata.ontology mockInv
+        let act1 = actual |> Seq.item 
+        let exp1 = 
+        Expect.equal act1 exp1 "incorrect output"
+    )

--- a/tests/ARCExpect.Tests/ARCGraphTests.fs
+++ b/tests/ARCExpect.Tests/ARCGraphTests.fs
@@ -9,21 +9,47 @@ open ControlledVocabulary
 
 let mockInv = 
     ARCMock.InvestigationMetadataTokens(
-        Investigation_Identifier = ["iid"],
-        Investigation_Title = ["ititle"],
-        Investigation_Description = ["idesc"],
-        Investigation_Person_Last_Name = ["Maus"; "Keider"; "müller"; ""; "oih"],
-        Investigation_Person_First_Name = ["Oliver"; ""; "andreas";],
-        Investigation_Person_Mid_Initials = ["L. I."; "C."],
-        Investigation_Person_Email = ["maus@nfdi4plants.org"],
-        Investigation_Person_Affiliation = [""; "Affe"],
-        Study_Identifier = ["sid"],
-        Study_Title = ["stitle"],
-        Study_Description = ["sdesc"],
-        Study_File_Name = [@"sid\isa.study.xlsx"],
-        Study_Assay_File_Name = [@"aid\isa.assay.xlsx"; @"aid2\isa.assay.xlsx"],
-        Study_Person_Last_Name = ["weil"],
-        Study_Person_First_Name = [""; "lukas"]
+        Investigation_Identifier = ["ArcPrototype"],
+        Investigation_Title = ["ArcPrototype"],
+        Investigation_Description = ["A prototypic ARC that implements all specification standards accordingly"],
+        Investigation_Person_Last_Name = ["Mühlhaus"; "Garth"; "Maus"],
+        Investigation_Person_First_Name = ["Timo"; "Christoph"; "Oliver";],
+        Investigation_Person_Email = ["timo.muehlhaus@rptu.de"; "garth@rptu.de"; "maus@nfdi4plants.org"],
+        Investigation_Person_Affiliation = ["RPTU University of Kaiserslautern"; "RPTU University of Kaiserslautern"; "RPTU University of Kaiserslautern"],
+        Investigation_Person_Phone = ["0 49 (0)631 205 4657"],
+        Investigation_Person_Address = ["RPTU University of Kaiserslautern, Paul-Ehrlich-Str. 23 , 67663 Kaiserslautern"; ""; "RPTU University of Kaiserslautern, Erwin-Schrödinger-Str. 56 , 67663 Kaiserslautern"],
+        Investigation_Person_Roles = ["principal investigator"; "principal investigator"; "research assistant"],
+        Investigation_Person_Roles_Term_Source_REF = ["scoro"; "scoro"; "scoro"],
+        Investigation_Person_Roles_Term_Accession_Number = ["http://purl.org/spar/scoro/principal-investigator"; "http://purl.org/spar/scoro/principal-investigator"; "http://purl.org/spar/scoro/research-assistant"],
+        Comment_ORCID = ["http://orcid.org/0000-0003-3925-6778"; ""; "0000-0002-8241-5300"],
+        Study_Identifier = ["experiment1_material"; "experiment2"],
+        Study_File_Name = [@"experiment1_material\isa.study.xlsx"; "experiment2\isa.study.xlsx"],
+        Study_Assay_File_Name = [@"measurement1\isa.assay.xlsx"; @"measurement2\isa.assay.xlsx"]
+    )
+    |> List.concat // use flat list
+    |> Seq.map (fun cvp -> cvp :> IParam)
+
+let mockStu =
+    ARCMock.StudyMetadataTokens(
+        Study_Identifier = ["experiment1_material"],
+        Study_Title = ["Prototype for experimental data"],
+        Study_Description = ["In this a devised study to have an exemplary experimental material description."],
+        Study_File_Name = ["experiment1_material\isa.study.xlsx"]
+    )
+    |> List.concat // use flat list
+    |> Seq.map (fun cvp -> cvp :> IParam)
+
+let mockAss =
+    ARCMock.AssayMetadataTokens(
+        Assay_File_Name = ["measurement1\isa.assay.xlsx"],
+        Assay_Performer_Last_Name = ["Maus"; "Katz"],
+        Assay_Performer_First_Name = ["Oliver"; "Marius"],
+        Assay_Performer_Mid_Initials = [""; "G."],
+        Assay_Performer_Email = ["maus@nfdi4plants.org"],
+        Assay_Performer_Affiliation = ["RPTU University of Kaiserslautern"],
+        Assay_Performer_Roles = ["research assistant"],
+        Assay_Performer_Roles_Term_Accession_Number = ["http://purl.org/spar/scoro/research-assistant"],
+        Assay_Performer_Roles_Term_Source_REF = ["scoro"]
     )
     |> List.concat // use flat list
     |> Seq.map (fun cvp -> cvp :> IParam)
@@ -31,45 +57,83 @@ let mockInv =
 
 [<Tests>]
 let ``fillTokenList tests`` =
-    testCase "returns correct output seq" (fun _ ->
-        let actual = ARCGraph.fillTokenList Terms.InvestigationMetadata.ontology mockInv
-        let act1 = actual |> Seq.tryItem 1 |> Option.bind (Seq.tryFind (fun t -> t |> Seq.exists (fun (t1,t2) -> t1 = ("Investigation Identifier", 1))))
-        Expect.isSome act1 "missing Investigation Identifier"
-        let act2 = 
-            Option.defaultValue Seq.empty act1 
-            |> Seq.map (fun (t1,t2) -> t2.Value |> ParamValue.getValueAsString) 
-            |> Seq.tryHead 
-            |> Option.defaultValue ""
-        let exp2 = "iid"
-        Expect.equal act2 exp2 "wrong Investigation Identifier"
+    testList "returns correct output seq" [
+        testCase "Investigation" (fun _ ->
+            let actual = ARCGraph.fillTokenList Terms.InvestigationMetadata.ontology mockInv
+            let act1 = actual |> Seq.tryItem 1 |> Option.bind (Seq.tryFind (fun t -> t |> Seq.exists (fun (t1,t2) -> t1 = ("Investigation Identifier", 1))))
+            Expect.isSome act1 "missing Investigation Identifier"
+            let act2 = 
+                Option.defaultValue Seq.empty act1 
+                |> Seq.map (fun (t1,t2) -> t2.Value |> ParamValue.getValueAsString) 
+                |> Seq.tryHead 
+                |> Option.defaultValue ""
+            let exp2 = "ArcPrototype"
+            Expect.equal act2 exp2 "wrong Investigation Identifier"
 
-        let act3 = actual |> Seq.tryItem 1 |> Option.bind (Seq.tryFind (fun t -> t |> Seq.exists (fun (t1,t2) -> t1 = ("Investigation Title", 1))))
-        Expect.isSome act3 "missing Investigation Title"
-        let act4 = 
-            Option.defaultValue Seq.empty act3 
-            |> Seq.map (fun (t1,t2) -> t2.Value |> ParamValue.getValueAsString) 
-            |> Seq.tryItem 2
-            |> Option.defaultValue ""
-        let exp4 = "ititle"
-        Expect.equal act4 exp4 "wrong Investigation Title"
+            let act3 = actual |> Seq.tryItem 1 |> Option.bind (Seq.tryFind (fun t -> t |> Seq.exists (fun (t1,t2) -> t1 = ("Investigation Title", 1))))
+            Expect.isSome act3 "missing Investigation Title"
+            let act4 = 
+                Option.defaultValue Seq.empty act3 
+                |> Seq.map (fun (t1,t2) -> t2.Value |> ParamValue.getValueAsString) 
+                |> Seq.tryItem 2
+                |> Option.defaultValue ""
+            let exp4 = "ArcPrototype"
+            Expect.equal act4 exp4 "wrong Investigation Title"
 
-        let act5 = actual |> Seq.tryItem 1 |> Option.bind (Seq.tryFind (fun t -> t |> Seq.exists (fun (t1,t2) -> t1 = ("Investigation Description", 1))))
-        Expect.isSome act5 "missing Investigation Description"
-        let act6 = 
-            Option.defaultValue Seq.empty act5
-            |> Seq.map (fun (t1,t2) -> t2.Value |> ParamValue.getValueAsString) 
-            |> Seq.tryItem 3
-            |> Option.defaultValue ""
-        let exp6 = "idesc"
-        Expect.equal act6 exp6 "wrong Investigation Description"
+            let act5 = actual |> Seq.tryItem 1 |> Option.bind (Seq.tryFind (fun t -> t |> Seq.exists (fun (t1,t2) -> t1 = ("Investigation Description", 1))))
+            Expect.isSome act5 "missing Investigation Description"
+            let act6 = 
+                Option.defaultValue Seq.empty act5
+                |> Seq.map (fun (t1,t2) -> t2.Value |> ParamValue.getValueAsString) 
+                |> Seq.tryItem 3
+                |> Option.defaultValue ""
+            let exp6 = "A prototypic ARC that implements all specification standards accordingly"
+            Expect.equal act6 exp6 "wrong Investigation Description"
 
-        let act7 = actual |> Seq.tryItem 3 |> Option.bind (Seq.tryFind (fun t -> t |> Seq.exists (fun (t1,t2) -> t1 = ("Investigation Person Last Name", 5))))
-        Expect.isSome act7 "missing Investigation Person Last Name"
-        let act8 = 
-            Option.defaultValue Seq.empty act7
-            |> Seq.map (fun (t1,t2) -> t2.Value |> ParamValue.getValueAsString) 
-            |> Seq.tryItem 0
-            |> Option.defaultValue ""
-        let exp8 = "oih"
-        Expect.equal act8 exp8 "wrong Investigation Person Last Name"
-    )
+            let act7 = actual |> Seq.tryItem 3 |> Option.bind (Seq.tryFind (fun t -> t |> Seq.exists (fun (t1,t2) -> t1 = ("Investigation Person Last Name", 2))))
+            Expect.isSome act7 "missing Investigation Person Last Name"
+            let act8 = 
+                Option.defaultValue Seq.empty act7
+                |> Seq.map (fun (t1,t2) -> t2.Value |> ParamValue.getValueAsString) 
+                |> Seq.tryItem 0
+                |> Option.defaultValue ""
+            let exp8 = "Garth"
+            Expect.equal act8 exp8 "wrong Investigation Person Last Name"
+
+            let act9 = actual |> Seq.tryItem 10 |> Option.bind (Seq.tryFind (fun t -> t |> Seq.exists (fun (t1,t2) -> t1 = ("Study Person Last Name", 1))))
+            Expect.isSome act9 "missing Study Person Last Name"
+            let act10 = 
+                Option.defaultValue Seq.empty act9
+                |> Seq.map (fun (t1,t2) -> t2.Value |> ParamValue.getValueAsString) 
+                |> Seq.tryItem 0
+                |> Option.defaultValue ""
+            let exp10 = "Mühlhaus"
+            Expect.equal act10 exp10 "wrong Study Person Last Name"
+        )
+
+        testCase "Study" (fun _ ->
+            let actual = ARCGraph.fillTokenList Terms.StudyMetadata.ontology mockStu
+            let act1 = actual |> Seq.tryItem 0 |> Option.bind (Seq.tryFind (fun t -> t |> Seq.exists (fun (t1,t2) -> t1 = ("Study Identifier", 1))))
+            Expect.isSome act1 "missing Study Identifier"
+            let act2 = 
+                Option.defaultValue Seq.empty act1 
+                |> Seq.map (fun (t1,t2) -> t2.Value |> ParamValue.getValueAsString) 
+                |> Seq.tryItem 0
+                |> Option.defaultValue ""
+            let exp2 = "experiment1_material"
+            Expect.equal act2 exp2 "wrong Study Identifier"
+        )
+
+        testCase "Assay" (fun _ ->
+            let actual = ARCGraph.fillTokenList Terms.StudyMetadata.ontology mockStu
+            let act1 = actual |> Seq.tryItem 0 |> Option.bind (Seq.tryFind (fun t -> t |> Seq.exists (fun (t1,t2) -> t1 = ("Assay Filename", 0))))
+            Expect.isSome act1 "missing Assay Filename"
+            let act2 = 
+                Option.defaultValue Seq.empty act1 
+                |> Seq.map (fun (t1,t2) -> t2.Value |> ParamValue.getValueAsString) 
+                |> Seq.tryItem 0
+                |> Option.defaultValue ""
+            let exp2 = @"measurement1\isa.assay.xlsx"
+            Expect.equal act2 exp2 "wrong Assay Filename"
+        )
+    ]

--- a/tests/ARCExpect.Tests/ARCGraphTests.fs
+++ b/tests/ARCExpect.Tests/ARCGraphTests.fs
@@ -100,15 +100,15 @@ let ``fillTokenList tests`` =
             let exp8 = "Garth"
             Expect.equal act8 exp8 "wrong Investigation Person Last Name"
 
-            let act9 = actual |> Seq.tryItem 10 |> Option.bind (Seq.tryFind (fun t -> t |> Seq.exists (fun (t1,t2) -> t1 = ("Study Person Last Name", 1))))
-            Expect.isSome act9 "missing Study Person Last Name"
+            let act9 = actual |> Seq.tryItem 4 |> Option.bind (Seq.tryFind (fun t -> t |> Seq.exists (fun (t1,t2) -> t1 = ("Study Identifier", 1))))
+            Expect.isSome act9 "missing Study Identifier"
             let act10 = 
                 Option.defaultValue Seq.empty act9
                 |> Seq.map (fun (t1,t2) -> t2.Value |> ParamValue.getValueAsString) 
                 |> Seq.tryItem 0
                 |> Option.defaultValue ""
-            let exp10 = "Mühlhaus"
-            Expect.equal act10 exp10 "wrong Study Person Last Name"
+            let exp10 = "experiment1_material"
+            Expect.equal act10 exp10 "wrong Study Identifier"
         )
 
         testCase "Study" (fun _ ->
@@ -125,8 +125,8 @@ let ``fillTokenList tests`` =
         )
 
         testCase "Assay" (fun _ ->
-            let actual = ARCGraph.fillTokenList Terms.StudyMetadata.ontology mockStu
-            let act1 = actual |> Seq.tryItem 0 |> Option.bind (Seq.tryFind (fun t -> t |> Seq.exists (fun (t1,t2) -> t1 = ("Assay Filename", 0))))
+            let actual = ARCGraph.fillTokenList Terms.AssayMetadata.ontology mockAss
+            let act1 = actual |> Seq.tryItem 2 |> Option.bind (Seq.tryFind (fun t -> t |> Seq.exists (fun (t1,t2) -> t1 = ("Assay Filename", 0))))
             Expect.isSome act1 "missing Assay Filename"
             let act2 = 
                 Option.defaultValue Seq.empty act1 

--- a/tests/ARCExpect.Tests/ARCGraphTests.fs
+++ b/tests/ARCExpect.Tests/ARCGraphTests.fs
@@ -4,6 +4,7 @@
 open ARCExpect
 open Expecto
 open ARCTokenization
+open ControlledVocabulary
 
 
 let mockInv = 
@@ -25,14 +26,50 @@ let mockInv =
         Study_Person_First_Name = [""; "lukas"]
     )
     |> List.concat // use flat list
-
+    |> Seq.map (fun cvp -> cvp :> IParam)
 
 
 [<Tests>]
 let ``fillTokenList tests`` =
     testCase "returns correct output seq" (fun _ ->
         let actual = ARCGraph.fillTokenList Terms.InvestigationMetadata.ontology mockInv
-        let act1 = actual |> Seq.item 
-        let exp1 = 
-        Expect.equal act1 exp1 "incorrect output"
+        let act1 = actual |> Seq.tryItem 1 |> Option.bind (Seq.tryFind (fun t -> t |> Seq.exists (fun (t1,t2) -> t1 = ("Investigation Identifier", 1))))
+        Expect.isSome act1 "missing Investigation Identifier"
+        let act2 = 
+            Option.defaultValue Seq.empty act1 
+            |> Seq.map (fun (t1,t2) -> t2.Value |> ParamValue.getValueAsString) 
+            |> Seq.tryHead 
+            |> Option.defaultValue ""
+        let exp2 = "iid"
+        Expect.equal act2 exp2 "wrong Investigation Identifier"
+
+        let act3 = actual |> Seq.tryItem 1 |> Option.bind (Seq.tryFind (fun t -> t |> Seq.exists (fun (t1,t2) -> t1 = ("Investigation Title", 1))))
+        Expect.isSome act3 "missing Investigation Title"
+        let act4 = 
+            Option.defaultValue Seq.empty act3 
+            |> Seq.map (fun (t1,t2) -> t2.Value |> ParamValue.getValueAsString) 
+            |> Seq.tryItem 2
+            |> Option.defaultValue ""
+        let exp4 = "ititle"
+        Expect.equal act4 exp4 "wrong Investigation Title"
+
+        let act5 = actual |> Seq.tryItem 1 |> Option.bind (Seq.tryFind (fun t -> t |> Seq.exists (fun (t1,t2) -> t1 = ("Investigation Description", 1))))
+        Expect.isSome act5 "missing Investigation Description"
+        let act6 = 
+            Option.defaultValue Seq.empty act5
+            |> Seq.map (fun (t1,t2) -> t2.Value |> ParamValue.getValueAsString) 
+            |> Seq.tryItem 3
+            |> Option.defaultValue ""
+        let exp6 = "idesc"
+        Expect.equal act6 exp6 "wrong Investigation Description"
+
+        let act7 = actual |> Seq.tryItem 3 |> Option.bind (Seq.tryFind (fun t -> t |> Seq.exists (fun (t1,t2) -> t1 = ("Investigation Person Last Name", 5))))
+        Expect.isSome act7 "missing Investigation Person Last Name"
+        let act8 = 
+            Option.defaultValue Seq.empty act7
+            |> Seq.map (fun (t1,t2) -> t2.Value |> ParamValue.getValueAsString) 
+            |> Seq.tryItem 0
+            |> Option.defaultValue ""
+        let exp8 = "oih"
+        Expect.equal act8 exp8 "wrong Investigation Person Last Name"
     )


### PR DESCRIPTION
This PR
- introduces a feature function `fillTokenList` which fills a token list from an ISA metadatasheet with a given structural ontology
  - and the respective unit tests
- ARCTokenization dependecy goes up to v2.0.0
- also fixes a bug where ARCGraph completion makes use of the structural metadata root term (which is NOT what we want)