### PR TITLE
`Validate.IParamCollection.forAll`

### DIFF
--- a/arc-validate.sln
+++ b/arc-validate.sln
@@ -61,6 +61,9 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "demo_notebooks", "demo_notebooks", "{A83F65C9-925E-437C-A457-EF8B9C6B154D}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "qcPackage_prototypes", "qcPackage_prototypes", "{9B3B6E39-DB2F-4A91-944B-EFAAD961FCE7}"
+	ProjectSection(SolutionItems) = preProject
+		playgrounds\qcPackage_prototypes\pride_prototype_v0.1.0.fsx = playgrounds\qcPackage_prototypes\pride_prototype_v0.1.0.fsx
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{DB01DF70-3713-4445-AC79-A09ECE093294}"
 EndProject
@@ -68,7 +71,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "content", "content", "{588E
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FSharpConsole", "tests\FSharpConsole\FSharpConsole.fsproj", "{DE9F79F6-ABA2-4940-AEB6-D969AE752E6F}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Common", "tests\Common\Common.fsproj", "{C41FAD1A-6E44-4C11-B915-CD928E0ED72B}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Common", "tests\Common\Common.fsproj", "{C41FAD1A-6E44-4C11-B915-CD928E0ED72B}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "arc-validate", "arc-validate", "{E6A037FA-C367-4C2A-9B87-2A04CA25D3C9}"
 EndProject

--- a/playgrounds/qcPackage_prototypes/pride_prototype_v0.1.0.fsx
+++ b/playgrounds/qcPackage_prototypes/pride_prototype_v0.1.0.fsx
@@ -50,9 +50,6 @@ let invFileTokens =
     |> Seq.concat
     |> Seq.map snd
 
-Investigation.parseMetadataSheetsFromTokens() absoluteFilePaths |> List.concat |> Seq.iter (Param.getCvName >> printfn "%s")
-Investigation.parseMetadataSheetsFromTokens() absoluteFilePaths |> List.concat |> Seq.iter (Param.getTerm >> printfn "%A")
-
 let invFileTokensNoMdSecKeys =
     invFileTokens
     |> Seq.filter (Param.getValue >> (<>) Terms.StructuralTerms.metadataSectionKey.Name) 
@@ -76,6 +73,32 @@ let contactsEmails =
 let commis =
     invFileTokensNoMdSecKeys
     |> Seq.filter (Param.getTerm >> (=) Terms.StructuralTerms.userComment)
+
+
+
+// Helper functions:
+
+type ParamCollection = 
+
+    static member AllItemsSatisfyPredicate (predicate : #IParam -> bool) (paramCollection : #seq<#IParam>) =
+        use en = paramCollection.GetEnumerator()
+        let rec loop failString =
+            match en.MoveNext() with
+            | true ->
+                if predicate en.Current |> not then
+                    let em = ErrorMessage.ofIParam $"does not satisfy predicate" en.Current
+                    loop $"{failString}\n{em}"
+                else loop failString
+            | false -> failString
+        let failString = loop ""
+        if String.isNullOrEmpty failString |> not then
+            Expecto.Tests.failtestNoStackf "%s" failString
+
+
+let testl = Seq.take 5 invFileTokens |> List.ofSeq
+
+ParamCollection.AllItemsSatisfyPredicate (fun p -> p.Name = "Term Source Name") testl
+
 
 
 // Validation Cases:

--- a/src/ARCExpect/ErrorMessage.fs
+++ b/src/ARCExpect/ErrorMessage.fs
@@ -90,3 +90,42 @@ type ErrorMessage =
             str.AppendFormat(" > position '{0}'", position) |> ignore
         | None -> ()
         str.ToString()
+
+
+    static member ofIParamCollection error iParamCollection =
+
+        let iParam = Seq.head iParamCollection
+
+        let str = new StringBuilder()    
+        str.AppendFormat("['{0}', ..] {1}\n",  Param.getCvName iParam, error) |> ignore 
+
+        match Param.tryGetValueOfCvParamAttr "FilePath" iParam with
+        | Some path ->
+            str.AppendFormat(" > filePath '{0}'\n", path) |> ignore         
+        | None -> ()
+
+        match Param.tryGetValueOfCvParamAttr "Worksheet" iParam with
+        | Some sheet ->
+            str.AppendFormat(" > sheet '{0}'", sheet) |> ignore         
+        | None -> ()
+
+        match Param.tryGetValueOfCvParamAttr "Row" iParam with
+        | Some row -> 
+            str.AppendFormat(" > row '{0}'", row) |> ignore
+        | None -> ()
+
+        match Param.tryGetValueOfCvParamAttr "Column" iParam with
+        | Some column -> 
+            str.AppendFormat(" > column '{0}'", column) |> ignore
+        | None -> ()        
+                
+        match Param.tryGetValueOfCvParamAttr "Line" iParam with
+        | Some line ->
+            str.AppendFormat(" > line '{0}'", line) |> ignore
+        | None -> ()
+
+        match Param.tryGetValueOfCvParamAttr "Position" iParam with
+        | Some position -> 
+            str.AppendFormat(" > position '{0}'", position) |> ignore
+        | None -> ()
+        str.ToString()

--- a/src/ARCExpect/ValidationFunctions.fs
+++ b/src/ARCExpect/ValidationFunctions.fs
@@ -157,7 +157,7 @@ module Validate =
         /// </summary>
         /// <param name="projection">A function that evaluates to true if the element satisfies the requirements.</param>
         /// <param name="paramCollection">The IParam collection to validate.</param>
-        static member ParamsSatisfyPredicate (predicate : #IParam -> bool) (paramCollection : #seq<#IParam>) =
+        static member AllItemsSatisfyPredicate (predicate : #IParam -> bool) (paramCollection : #seq<#IParam>) =
             use en = paramCollection.GetEnumerator()
             let rec loop () =
                 match en.MoveNext() with

--- a/src/ARCExpect/ValidationFunctions.fs
+++ b/src/ARCExpect/ValidationFunctions.fs
@@ -165,6 +165,7 @@ module Validate =
                     if predicate en.Current |> not then
                         ErrorMessage.ofIParam $"does not satisfy predicate" en.Current
                         |> Expecto.Tests.failtestNoStackf "%s"
+                        loop ()
                     else loop ()
                 | false -> ()
             loop ()

--- a/src/ARCExpect/ValidationFunctions.fs
+++ b/src/ARCExpect/ValidationFunctions.fs
@@ -153,9 +153,9 @@ module Validate =
             |> Expecto.Tests.failtestNoStackf "%s"
 
         /// <summary>
-        /// Validates if all elements in the given IParam collection satisfy the projection function.
+        /// Validates if all elements in the given IParam collection satisfy the predicate function.
         /// </summary>
-        /// <param name="projection">A function that evaluates to true if the element satisfies the requirements.</param>
+        /// <param name="predicate">A function that evaluates to true if the element satisfies the requirements.</param>
         /// <param name="paramCollection">The IParam collection to validate.</param>
         static member AllItemsSatisfyPredicate (predicate : #IParam -> bool) (paramCollection : #seq<#IParam>) =
             use en = paramCollection.GetEnumerator()

--- a/src/ARCExpect/ValidationFunctions.fs
+++ b/src/ARCExpect/ValidationFunctions.fs
@@ -157,8 +157,8 @@ module Validate =
         /// </summary>
         /// <param name="projection">A function that evaluates to true if the element satisfies the requirements.</param>
         /// <param name="paramCollection">The IParam collection to validate.</param>
-        static member forAll (projection : #IParam -> bool) (paramCollection : #seq<#IParam>) =
-            match Seq.forall projection paramCollection with
+        static member ParamsSatisfyPredicate (predicate : #IParam -> bool) (paramCollection : #seq<#IParam>) =
+            match Seq.forall predicate paramCollection with
             | true  -> ()
             | false ->
                 ErrorMessage.ofIParamCollection $"does not exist" paramCollection

--- a/src/ARCExpect/ValidationFunctions.fs
+++ b/src/ARCExpect/ValidationFunctions.fs
@@ -5,7 +5,6 @@ open ARCExpect
 open ARCTokenization.StructuralOntology
 open FSharpAux
 
-FSharpx.Collections.Array.catOptions
 
 /// <summary>
 /// Top level API for performing validation.

--- a/src/ARCExpect/ValidationFunctions.fs
+++ b/src/ARCExpect/ValidationFunctions.fs
@@ -3,6 +3,9 @@
 open ControlledVocabulary
 open ARCExpect
 open ARCTokenization.StructuralOntology
+open FSharpAux
+
+FSharpx.Collections.Array.catOptions
 
 /// <summary>
 /// Top level API for performing validation.
@@ -159,16 +162,17 @@ module Validate =
         /// <param name="paramCollection">The IParam collection to validate.</param>
         static member AllItemsSatisfyPredicate (predicate : #IParam -> bool) (paramCollection : #seq<#IParam>) =
             use en = paramCollection.GetEnumerator()
-            let rec loop () =
+            let rec loop failString =
                 match en.MoveNext() with
                 | true ->
                     if predicate en.Current |> not then
-                        ErrorMessage.ofIParam $"does not satisfy predicate" en.Current
-                        |> Expecto.Tests.failtestNoStackf "%s"
-                        loop ()
-                    else loop ()
-                | false -> ()
-            loop ()
+                        let em = ErrorMessage.ofIParam $"does not satisfy predicate" en.Current
+                        loop $"{failString}\n{em}"
+                    else loop failString
+                | false -> failString
+            let failString = loop ""
+            if String.isNullOrEmpty failString |> not then
+                Expecto.Tests.failtestNoStackf "%s" failString
 
 
     /// <summary>

--- a/src/ARCExpect/ValidationFunctions.fs
+++ b/src/ARCExpect/ValidationFunctions.fs
@@ -134,7 +134,7 @@ module Validate =
                 |> Expecto.Tests.failtestNoStackf "%s"
 
         /// <summary>
-        /// Validates if the given Param is contained in the given collection át least once.
+        /// Validates if the given Param is contained in the given collection at least once.
         /// </summary>
         /// <param name="expectedParam">the param expected to occur at least once in the given collection</param>
         /// <param name="paramCollection">The param collection to validate</param>
@@ -151,6 +151,18 @@ module Validate =
             expectedParam
             |> ErrorMessage.ofIParam $"does not exist"
             |> Expecto.Tests.failtestNoStackf "%s"
+
+        /// <summary>
+        /// Validates if all elements in the given IParam collection satisfy the projection function.
+        /// </summary>
+        /// <param name="projection">A function that evaluates to true if the element satisfies the requirements.</param>
+        /// <param name="paramCollection">The IParam collection to validate.</param>
+        static member forAll (projection : #IParam -> bool) (paramCollection : #seq<#IParam>) =
+            match Seq.forall projection paramCollection with
+            | true  -> ()
+            | false ->
+                ErrorMessage.ofIParamCollection $"does not exist" paramCollection
+                |> Expecto.Tests.failtestNoStackf "%s"
 
 
     /// <summary>

--- a/tests/ARCExpect.Tests/ARCExpect.Tests.fsproj
+++ b/tests/ARCExpect.Tests/ARCExpect.Tests.fsproj
@@ -11,6 +11,7 @@
     <EmbeddedResource Remove="CLITests\**" />
     <Compile Include="InternalUtilsTests.fs" />
     <Compile Include="ReferenceObjects.fs" />
+    <Compile Include="ErrorMessageTests.fs" />
     <Compile Include="ExpectoExtensionsTests.fs" />
     <Compile Include="PathConfigTests.fs" />
     <Compile Include="DirTokenizerTests.fs" />

--- a/tests/ARCExpect.Tests/ErrorMessageTests.fs
+++ b/tests/ARCExpect.Tests/ErrorMessageTests.fs
@@ -1,0 +1,19 @@
+﻿module ErrorMessageTests
+
+
+open Expecto
+open ARCExpect
+open ControlledVocabulary
+
+
+let dummyIParam = CvParam("test:0", "testTerm", "test", ParamValue.Value "no val")
+dummyIParam.AddAttribute(CvParam())
+
+
+[<Tests>]
+let ``ErrorMessage tests`` =
+    testList "ErrorMessage" [
+        testList "ofIParamCollection" [
+            testCase "resolves correctly"
+        ]
+    ]

--- a/tests/ARCExpect.Tests/ErrorMessageTests.fs
+++ b/tests/ARCExpect.Tests/ErrorMessageTests.fs
@@ -7,13 +7,15 @@ open ControlledVocabulary
 
 
 let dummyIParam = CvParam("test:0", "testTerm", "test", ParamValue.Value "no val")
-dummyIParam.AddAttribute(CvParam())
+let dummyIParamColl = List.init 3 (fun _ -> dummyIParam)
 
 
 [<Tests>]
 let ``ErrorMessage tests`` =
     testList "ErrorMessage" [
         testList "ofIParamCollection" [
-            testCase "resolves correctly"
+            testCase "resolves correctly" <| fun _ ->
+                let eMsg = ErrorMessage.ofIParamCollection "does not satisfy" dummyIParamColl
+                Expect.equal eMsg "['testTerm', ..] does not satisfy\n" "resolved incorrectly"
         ]
     ]


### PR DESCRIPTION
This PR
- adds the `forAll` function in `Validate.IParamCollection` module/type
- also adds an `ErrorMessage.ofIParamCollection` function according to this
  - provides a unit test for this functionality