### PR TITLE
Add side-by-side usage of preview index and AVPR packages

### DIFF
--- a/src/ARCValidationPackages/ARCValidationPackages.fsproj
+++ b/src/ARCValidationPackages/ARCValidationPackages.fsproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Fake.DotNet.Cli" Version="[6.0.0]" />
     <PackageReference Include="FsHttp" Version="[14.5.0]" />
 	<PackageReference Include="AVPRClient" Version="[0.0.4]" />
-	<PackageReference Include="AVPRIndex" Version="[0.0.8]" />
+	<PackageReference Include="AVPRIndex" Version="[0.1.0]" />
   </ItemGroup>
 
 </Project>

--- a/src/ARCValidationPackages/AVPRAPI.fs
+++ b/src/ARCValidationPackages/AVPRAPI.fs
@@ -25,6 +25,16 @@ type AVPRAPI () =
         |> Async.AwaitTask
         |> Async.RunSynchronously
         
+    member this.downloadPackageScript (packageName: string, ?version: string) =
+        let vp = 
+            match version with
+            | Some v ->  this.GetPackageByNameAndVersion packageName v
+            | None -> this.GetPackageByName packageName
+        let script =
+            vp.PackageContent
+            |> Text.Encoding.UTF8.GetString
+        script
+        
     //member this.downloadPackageScript (packageIndex: ValidationPackageIndex) =
         
     //    let validationPackage =

--- a/src/ARCValidationPackages/AVPRAPI.fs
+++ b/src/ARCValidationPackages/AVPRAPI.fs
@@ -6,24 +6,85 @@ open AVPRIndex
 open System
 open System.Net.Http
 
+module AVPRAPI =
+
+    module Errors =
+
+        type ResponseNullError(msg : string) =
+            inherit Exception(msg)
+
+        type ServerSideError(msg : string) =
+            inherit Exception(msg)
+
+        type UnexpectedStatusCodeError(msg : string) =
+            inherit Exception(msg)
+
+        type DeserializationError(msg : string) =
+            inherit Exception(msg)
+            
+        type GeneralError(msg : string) =
+            inherit Exception(msg)
+
 type AVPRAPI () =
     member private this.BaseUri = Uri("https://avpr.nfdi4plants.org")
     member private this.HttpClienHandler = new HttpClientHandler (UseCookies = false)
     member private this.HttpClient = new HttpClient(this.HttpClienHandler, true, BaseAddress=this.BaseUri)
     member this.Client = AVPRClient.Client(this.HttpClient)
     member this.GetAllPackages (): ValidationPackage [] = 
-        this.Client.GetAllPackagesAsync(System.Threading.CancellationToken.None)
-        |> Async.AwaitTask
-        |> Async.RunSynchronously
-        |> Seq.toArray
+        try
+            this.Client.GetAllPackagesAsync(System.Threading.CancellationToken.None)
+            |> Async.AwaitTask
+            |> Async.RunSynchronously
+            |> Seq.toArray
+        with
+        | :? AVPRClient.ApiException as e -> 
+            match e.Message with
+            | m when m.ToLower().Contains "response was null" -> 
+                raise (AVPRAPI.Errors.ResponseNullError(e.Message))
+            | m when m.ToLower().Contains "http status code of the response was not expected" -> 
+                raise (AVPRAPI.Errors.UnexpectedStatusCodeError(e.Message))
+            | m when m.ToLower().Contains "server side error occurred" -> 
+                raise (AVPRAPI.Errors.ServerSideError(e.Message))
+            | m when m.ToLower().Contains "could not deserialize the response body string" -> 
+                raise (AVPRAPI.Errors.DeserializationError(e.Message))
+            | _ -> 
+                raise (AVPRAPI.Errors.GeneralError(e.Message))
     member this.GetPackageByName (packageName: string): ValidationPackage =
-        this.Client.GetLatestPackageByNameAsync(packageName)
-        |> Async.AwaitTask
-        |> Async.RunSynchronously
+        try
+            this.Client.GetLatestPackageByNameAsync(packageName)
+            |> Async.AwaitTask
+            |> Async.RunSynchronously
+        with
+        | :? AVPRClient.ApiException as e -> 
+            match e.Message with
+            | m when m.ToLower().Contains "response was null" -> 
+                raise (AVPRAPI.Errors.ResponseNullError(e.Message))
+            | m when m.ToLower().Contains "http status code of the response was not expected" -> 
+                raise (AVPRAPI.Errors.UnexpectedStatusCodeError(e.Message))
+            | m when m.ToLower().Contains "server side error occurred" -> 
+                raise (AVPRAPI.Errors.ServerSideError(e.Message))
+            | m when m.ToLower().Contains "could not deserialize the response body string" -> 
+                raise (AVPRAPI.Errors.DeserializationError(e.Message))
+            | _ -> 
+                raise (AVPRAPI.Errors.GeneralError(e.Message))
     member this.GetPackageByNameAndVersion (packageName: string) (version: string): ValidationPackage =
-        this.Client.GetPackageByNameAndVersionAsync(packageName, version)
-        |> Async.AwaitTask
-        |> Async.RunSynchronously
+        try
+            this.Client.GetPackageByNameAndVersionAsync(packageName, version)
+            |> Async.AwaitTask
+            |> Async.RunSynchronously
+        with
+        | :? AVPRClient.ApiException as e -> 
+            match e.Message with
+            | m when m.ToLower().Contains "response was null" -> 
+                raise (AVPRAPI.Errors.ResponseNullError(e.Message))
+            | m when m.ToLower().Contains "http status code of the response was not expected" -> 
+                raise (AVPRAPI.Errors.UnexpectedStatusCodeError(e.Message))
+            | m when m.ToLower().Contains "server side error occurred" -> 
+                raise (AVPRAPI.Errors.ServerSideError(e.Message))
+            | m when m.ToLower().Contains "could not deserialize the response body string" -> 
+                raise (AVPRAPI.Errors.DeserializationError(e.Message))
+            | _ -> 
+                raise (AVPRAPI.Errors.GeneralError(e.Message))
         
     member this.downloadPackageScript (packageName: string, ?version: string) =
         let vp = 
@@ -34,11 +95,3 @@ type AVPRAPI () =
             vp.PackageContent
             |> Text.Encoding.UTF8.GetString
         script
-        
-    //member this.downloadPackageScript (packageIndex: ValidationPackageIndex) =
-        
-    //    let validationPackage =
-    //        this.GetPackageByNameAndVersion 
-    //            packageIndex.Metadata.Name
-    //            (ValidationPackageMetadata.getSemanticVersionString packageIndex.Metadata)
-    //    Text.Encoding.UTF8.GetString validationPackage.PackageContent

--- a/src/ARCValidationPackages/Config.fs
+++ b/src/ARCValidationPackages/Config.fs
@@ -25,12 +25,12 @@ type Config = {
             ConfigFilePath = configFilePath
         }
 
-    static member initDefault(?Token, ?ConfigPath, ?CacheFolder) = 
+    static member initDefault(?Token, ?ConfigPath, ?CacheFolderPreview, ?CacheFolderRelease) = 
         Config.create(
             packageIndex = GitHubAPI.getPackageIndex(?Token = Token),
             indexLastUpdated = System.DateTimeOffset.Now,
-            packageCacheFolderPreview = defaultArg CacheFolder (Defaults.PACKAGE_CACHE_FOLDER_PREVIEW()),
-            packageCacheFolderRelease = defaultArg CacheFolder (Defaults.PACKAGE_CACHE_FOLDER_RELEASE()),
+            packageCacheFolderPreview = defaultArg CacheFolderPreview (Defaults.PACKAGE_CACHE_FOLDER_PREVIEW()),
+            packageCacheFolderRelease = defaultArg CacheFolderRelease (Defaults.PACKAGE_CACHE_FOLDER_RELEASE()),
             configFilePath = defaultArg ConfigPath (Defaults.CONFIG_FILE_PATH())
         )
     static member indexContainsPackages (packageName: string) (config: Config) =
@@ -94,11 +94,11 @@ type Config = {
         |> File.ReadAllText
         |> fun jsonString -> JsonSerializer.Deserialize<Config>(jsonString, Defaults.SERIALIZATION_OPTIONS)
 
-    static member get (?Path: string, ?CacheFolder:string, ?Token:string) =
+    static member get (?Path: string, ?CacheFolderPreview:string, ?CacheFolderRelease:string, ?Token:string) =
         if Config.exists(?Path = Path) then
             Config.read(?Path = Path)
         else
-            Config.initDefault(?Token = Token, ?ConfigPath = Path, ?CacheFolder = CacheFolder)
+            Config.initDefault(?Token = Token, ?ConfigPath = Path, ?CacheFolderPreview = CacheFolderPreview, ?CacheFolderRelease = CacheFolderRelease)
 
     static member write (?Path: string) =
         fun (config: Config) ->

--- a/src/ARCValidationPackages/Config.fs
+++ b/src/ARCValidationPackages/Config.fs
@@ -6,19 +6,22 @@ open AVPRIndex.Domain
 type Config = {
     PackageIndex: ValidationPackageIndex []
     IndexLastUpdated: System.DateTimeOffset
-    PackageCacheFolder: string
+    PackageCacheFolderPreview: string
+    PackageCacheFolderRelease: string
     ConfigFilePath: string
 } with
     static member create (
         packageIndex: ValidationPackageIndex [],
         indexLastUpdated: System.DateTimeOffset,
-        packageCacheFolder: string,
+        packageCacheFolderPreview: string,
+        packageCacheFolderRelease: string,
         configFilePath: string
     ) =
         {
             PackageIndex = packageIndex
             IndexLastUpdated = indexLastUpdated
-            PackageCacheFolder = packageCacheFolder
+            PackageCacheFolderPreview = packageCacheFolderPreview
+            PackageCacheFolderRelease = packageCacheFolderRelease
             ConfigFilePath = configFilePath
         }
 
@@ -26,7 +29,8 @@ type Config = {
         Config.create(
             packageIndex = GitHubAPI.getPackageIndex(?Token = Token),
             indexLastUpdated = System.DateTimeOffset.Now,
-            packageCacheFolder = defaultArg CacheFolder (Defaults.PACKAGE_CACHE_FOLDER_PREVIEW()),
+            packageCacheFolderPreview = defaultArg CacheFolder (Defaults.PACKAGE_CACHE_FOLDER_PREVIEW()),
+            packageCacheFolderRelease = defaultArg CacheFolder (Defaults.PACKAGE_CACHE_FOLDER_RELEASE()),
             configFilePath = defaultArg ConfigPath (Defaults.CONFIG_FILE_PATH())
         )
     static member indexContainsPackages (packageName: string) (config: Config) =

--- a/src/ARCValidationPackages/Domain.fs
+++ b/src/ARCValidationPackages/Domain.fs
@@ -36,7 +36,7 @@ type CachedValidationPackage =
             }
 
         /// <summary>
-        /// Creates a new ARCValidationPackage from a ValidationPackageIndex, with the CacheDate set to the current or optionally a custom date, and the LocalPath set to the default cache folder or custom folder.
+        /// Creates a new ARCValidationPackage from a ValidationPackageIndex, with the CacheDate set to the current or optionally a custom date, and the LocalPath set to the default preview cache folder or custom folder.
         /// </summary>
         /// <param name="packageIndex">The input package index entry</param>
         /// <param name="Date">Optional. The date to set the CacheDate to. Defaults to the current date.</param>
@@ -50,7 +50,7 @@ type CachedValidationPackage =
             )
 
         /// <summary>
-        /// Creates a new ARCValidationPackage from a package name only, with the CacheDate set to the current or optionally a custom date, and the LocalPath set to the default cache folder or custom folder.
+        /// Creates a new ARCValidationPackage from a package name only, with the CacheDate set to the current or optionally a custom date, and the LocalPath set to the default preview cache folder or custom folder.
         /// </summary>
         /// <param name="packageName"></param>
         /// <param name="Date"></param>
@@ -62,6 +62,20 @@ type CachedValidationPackage =
                 cacheDate = (defaultArg Date System.DateTimeOffset.Now),
                 localPath = (System.IO.Path.Combine(path, $"{packageName}.fsx").Replace("\\","/")),
                 metadata = ValidationPackageMetadata()
+            )
+
+        /// <summary>
+        /// Creates a new ARCValidationPackage from a ValidationPackageMetadata, with the CacheDate set to the current or optionally a custom date, and the LocalPath set to the default release cache folder or custom folder.
+        /// </summary>
+        /// <param name="packageIndex">The input package index entry</param>
+        /// <param name="Date">Optional. The date to set the CacheDate to. Defaults to the current date.</param>
+        static member ofPackageMetadata (packageMetadata: ValidationPackageMetadata, ?Date: System.DateTimeOffset, ?CacheFolder: string) =
+            let path = defaultArg CacheFolder (Defaults.PACKAGE_CACHE_FOLDER_RELEASE())
+            CachedValidationPackage.create(
+                fileName = packageMetadata.Name,
+                cacheDate = (defaultArg Date System.DateTimeOffset.Now),
+                localPath = (System.IO.Path.Combine(path, $"{packageMetadata.Name}.fsx").Replace("\\","/")),
+                metadata = packageMetadata
             )
 
         /// <summary>

--- a/src/ARCValidationPackages/Domain.fs
+++ b/src/ARCValidationPackages/Domain.fs
@@ -12,6 +12,7 @@ module ValidationPackageMetadata =
 
 module ValidationPackageIndex =
     let getSemanticVersionString(i: ValidationPackageIndex) = $"{i.Metadata.MajorVersion}.{i.Metadata.MinorVersion}.{i.Metadata.PatchVersion}"
+
 /// <summary>
 /// represents the locally installed version of a validation package, e.g. the path to the local file and the date it was cached.
 /// </summary>
@@ -74,7 +75,7 @@ type CachedValidationPackage =
             CachedValidationPackage.create(
                 fileName = packageMetadata.Name,
                 cacheDate = (defaultArg Date System.DateTimeOffset.Now),
-                localPath = (System.IO.Path.Combine(path, $"{packageMetadata.Name}.fsx").Replace("\\","/")),
+                localPath = (System.IO.Path.Combine(path, $"{packageMetadata.Name}@{packageMetadata.MajorVersion}.{packageMetadata.MinorVersion}.{packageMetadata.PatchVersion}.fsx").Replace("\\","/")),
                 metadata = packageMetadata
             )
 

--- a/src/ARCValidationPackages/PackageCache.fs
+++ b/src/ARCValidationPackages/PackageCache.fs
@@ -145,29 +145,25 @@ type PackageCache =
         cache.Remove(name) |> ignore
         cache
 
-    static member exists (?Path: string) =
-        let path = defaultArg Path (Defaults.PACKAGE_CACHE_FILE_PATH_PREVIEW())
+    static member exists (path: string) =
         File.Exists(path)
 
-    static member read (?Path: string) =
-        let path = defaultArg Path (Defaults.PACKAGE_CACHE_FILE_PATH_PREVIEW())
+    static member read (path: string) =
         path
         |> File.ReadAllText
         |> fun jsonString -> JsonSerializer.Deserialize<PackageCache>(jsonString, Defaults.SERIALIZATION_OPTIONS)
 
-    static member get (?Folder: string, ?FileName: string) =
+    static member get (folder: string, ?FileName: string) =
         let fileName = defaultArg FileName (Defaults.PACKAGE_CACHE_FILE_NAME)
-        let folder = defaultArg Folder (Defaults.PACKAGE_CACHE_FOLDER_PREVIEW())
         let path = Path.Combine(folder, fileName)
         if PackageCache.exists(path) then
             PackageCache.read(path)
         else
             PackageCache.create([])
 
-    static member write (?Folder: string, ?FileName: string) =
+    static member write (folder: string, ?FileName: string) =
         fun (cache: PackageCache) ->
             let fileName = defaultArg FileName (Defaults.PACKAGE_CACHE_FILE_NAME)
-            let folder = defaultArg Folder (Defaults.PACKAGE_CACHE_FOLDER_PREVIEW())
             let path = Path.Combine(folder, fileName)
             System.IO.FileInfo(path).Directory.Create(); // ensures directory exists
             JsonSerializer.Serialize(cache, Defaults.SERIALIZATION_OPTIONS)

--- a/src/ARCValidationPackages/TopLevelAPI.fs
+++ b/src/ARCValidationPackages/TopLevelAPI.fs
@@ -404,7 +404,8 @@ type AVPR =
             // not cached -> download and cache
             AVPR.SaveAndCachePackage(
                 cache = cache,
-                packageName = packageName
+                packageName = packageName,
+                ?packageVersion = SemVer
             )
 
     static member UninstallPackage(

--- a/src/ARCValidationPackages/TopLevelAPI.fs
+++ b/src/ARCValidationPackages/TopLevelAPI.fs
@@ -302,12 +302,10 @@ type AVPR =
             | _ -> Error (PackageInstallError.DownloadError(packageName, e.Message))
             
     static member InstallPackage(
-        config: Config,
         cache: PackageCache,
         packageName: string,
         ?SemVer: string,
-        ?Verbose: bool,
-        ?Token: string
+        ?Verbose: bool
     ) =
         let verbose = defaultArg Verbose false
         let cachedPackage =

--- a/src/ARCValidationPackages/TopLevelAPI.fs
+++ b/src/ARCValidationPackages/TopLevelAPI.fs
@@ -1,4 +1,6 @@
-﻿namespace ARCValidationPackages
+﻿namespace ARCValidationPackages.API
+
+open ARCValidationPackages
 open System.IO
 open AVPRClient
 open AVPRIndex
@@ -28,10 +30,24 @@ type PackageUninstallError =
 | IOError of msg: string
 | APIError of APIError
 
-type API =
+/// Top-level API functions that do not depend on wether the package source is the preview index or the AVPR API.
+type Common = 
 
+    /// <summary>
+    /// Returns the current config and package caches for both preview and avpr packages.
+    ///
+    /// The return value is a tuple containing (config, avprCache, previewCache).
+    /// 
+    /// If no custom pathhs for config and/or cache are provided, the default paths are used.
+    /// 
+    /// Config and caches are read from the provided paths or defaults, if they exist. If they do not exist, they are created.
+    /// </summary>
+    /// <param name="ConfigPath"></param>
+    /// <param name="CacheFolderPreview"></param>
+    /// <param name="CacheFolderRelease"></param>
+    /// <param name="CacheFileName"></param>
+    /// <param name="Token"></param>
     static member GetSyncedConfigAndCache(
-        release: bool,
         ?ConfigPath: string,
         ?CacheFolderPreview: string,
         ?CacheFolderRelease: string,
@@ -43,58 +59,46 @@ type API =
             let cacheFolderRelease = defaultArg CacheFolderRelease (Defaults.PACKAGE_CACHE_FOLDER_RELEASE())
             let config = Config.get(?Path = ConfigPath, ?CacheFolderPreview= CacheFolderPreview, ?CacheFolderRelease = CacheFolderRelease, ?Token = Token)
             config |> Config.write(?Path = ConfigPath)
-            let cache =
-                if release then
-                    let c = PackageCache.get(folder = cacheFolderRelease, ?FileName = CacheFileName)
-                    c |> PackageCache.write(folder = cacheFolderRelease, ?FileName = CacheFileName)
-                    c
-                else
-                    let c = PackageCache.get(folder = cacheFolderPreview, ?FileName = CacheFileName)
-                    c |> PackageCache.write(folder = cacheFolderPreview, ?FileName = CacheFileName)
-                    c
 
-            Ok (config, cache)
+            let avprCache =
+                let c = PackageCache.get(folder = cacheFolderRelease, ?FileName = CacheFileName)
+                c |> PackageCache.write(folder = cacheFolderRelease, ?FileName = CacheFileName)
+                c
+
+            let previewCache = 
+                let c = PackageCache.get(folder = cacheFolderPreview, ?FileName = CacheFileName)
+                c |> PackageCache.write(folder = cacheFolderPreview, ?FileName = CacheFileName)
+                c
+
+            Ok (config, avprCache, previewCache)
         with e ->
             Error (GetSyncedConfigAndCacheError.SyncError(e.Message))
 
-    static member SaveAndCachePackage (
+    /// <summary>
+    /// Lists all cached packages in the given cache.
+    /// </summary>
+    /// <param name="cache"></param>
+    /// <param name="Verbose"></param>
+    static member ListCachedPackages(
         cache: PackageCache,
-        indexedPackage: ValidationPackageIndex,
-        ?CacheFolder: string,
-        ?Token: string
+        ?Verbose: bool
     ) =
-        let cacheFolder = defaultArg CacheFolder (Defaults.PACKAGE_CACHE_FOLDER_PREVIEW())
-        let package = CachedValidationPackage.ofPackageIndex(indexedPackage, ?CacheFolder = CacheFolder)
-        try 
-            GitHubAPI.downloadPackageScript(indexedPackage, ?Token = Token)
-            |> fun script -> 
-                File.WriteAllText(
-                    package.LocalPath,
-                    script
-                )
-
-            cache
-            |> PackageCache.addPackage package
-            |> PackageCache.write(cacheFolder)
-
-            Ok ($"installed package {package.FileName} at {package.LocalPath}")
-                
+        try
+            cache 
+            |> PackageCache.getAllPackages
+            |> Ok
+        
         with e ->
-            match e with
-            | :? GitHubAPI.Errors.RateLimitError as e -> 
-                (RateLimitExceeded e.Message)
-                |> PackageInstallError.APIError
-                |> Error
-            | :? GitHubAPI.Errors.SerializationError as e ->
-                (SerializationError e.Message)
-                |> PackageInstallError.APIError
-                |> Error
-            | :? GitHubAPI.Errors.NotFoundError as e ->
-                (NotFoundError e.Message)
-                |> PackageInstallError.APIError
-                |> Error
-            | _ -> Error (PackageInstallError.DownloadError(package.FileName, e.Message))
+            Error e.Message
 
+/// Top-level API functions using the preview index as package source
+type Preview = 
+
+    /// <summary>
+    /// Syncs the local copy of the preview index with the latest version on remote index.
+    /// </summary>
+    /// <param name="config"></param>
+    /// <param name="Token"></param>
     static member UpdateIndex (
         config: Config,
         ?Token: string
@@ -129,6 +133,85 @@ type API =
 
             | _ -> Error (UpdateIndexError.DownloadError(e.Message))
 
+    /// <summary>
+    /// Lists all indexed packages in the local preview index.
+    /// </summary>
+    /// <param name="config"></param>
+    /// <param name="Verbose"></param>
+    static member ListIndexedPackages(
+        config: Config,
+        ?Verbose: bool
+    ) =
+        try
+            config.PackageIndex
+            |> Array.toList
+            |> Ok
+        
+        with e ->
+            Error e.Message
+
+    /// <summary>
+    /// Adds the given indexed preview package to the preview cache and writes the cache and package to disk.
+    /// </summary>
+    /// <param name="cache"></param>
+    /// <param name="indexedPackage"></param>
+    /// <param name="CacheFolder"></param>
+    /// <param name="Token"></param>
+    static member SaveAndCachePackage (
+        cache: PackageCache,
+        indexedPackage: ValidationPackageIndex,
+        ?CacheFolder: string,
+        ?Token: string
+    ) =
+        let cacheFolder = defaultArg CacheFolder (Defaults.PACKAGE_CACHE_FOLDER_PREVIEW())
+        let package = CachedValidationPackage.ofPackageIndex(indexedPackage, ?CacheFolder = CacheFolder)
+        try 
+            GitHubAPI.downloadPackageScript(indexedPackage, ?Token = Token)
+            |> fun script -> 
+                File.WriteAllText(
+                    package.LocalPath,
+                    script
+                )
+
+            cache
+            |> PackageCache.addPackage package
+            |> PackageCache.write(cacheFolder)
+
+            Ok ($"installed preview package {package.FileName}@{ValidationPackageMetadata.getSemanticVersionString package.Metadata} at {package.LocalPath}")
+                
+        with e ->
+            match e with
+            | :? GitHubAPI.Errors.RateLimitError as e -> 
+                (RateLimitExceeded e.Message)
+                |> PackageInstallError.APIError
+                |> Error
+            | :? GitHubAPI.Errors.SerializationError as e ->
+                (SerializationError e.Message)
+                |> PackageInstallError.APIError
+                |> Error
+            | :? GitHubAPI.Errors.NotFoundError as e ->
+                (NotFoundError e.Message)
+                |> PackageInstallError.APIError
+                |> Error
+            | _ -> Error (PackageInstallError.DownloadError(package.FileName, e.Message))
+
+    /// <summary>
+    /// Installs the given preview package from the preview index.
+    ///
+    /// If the a package with the given name (and optional version) does not exist on the local preview index, an error is returned.
+    ///
+    /// If the package exists on the local preview index, the package is downloaded and installed.
+    ///
+    /// If no version is provided, the latest version of the package is installed.
+    ///
+    /// If a package with the given name (and optional version) is already installed, the preview index is updated and the latest version of the package is installed.
+    /// </summary>
+    /// <param name="config"></param>
+    /// <param name="cache"></param>
+    /// <param name="packageName"></param>
+    /// <param name="SemVer"></param>
+    /// <param name="Verbose"></param>
+    /// <param name="Token"></param>
     static member InstallPackage(
         config: Config,
         cache: PackageCache,
@@ -138,8 +221,9 @@ type API =
         ?Token: string
     ) =
         let verbose = defaultArg Verbose false
+
         if (Config.indexContainsPackages packageName config) then
-            // package exists on the local index
+            // package exists on the local preview index
 
             let indexedPackage = 
                 match SemVer with
@@ -163,13 +247,13 @@ type API =
                     if verbose then printfn $"package {packageName} is already cached locally from {cachedPackage.CacheDate}"
                     if verbose then printfn $"updating package index and looking for a newer version..."
 
-                    match API.UpdateIndex(config, ?Token = Token) with
+                    match Preview.UpdateIndex(config, ?Token = Token) with
                     | Ok updatedConfig -> 
                         let updatedIndexPackage = Config.getIndexedPackageByNameAndVersion packageName (CachedValidationPackage.getSemanticVersionString cachedPackage) updatedConfig
                         if updatedIndexPackage.LastUpdated > indexedPackage.LastUpdated then
                             // package on remote index is newer, download package and cache.
                             if verbose then printfn $"package {packageName} is available in a newer version({updatedIndexPackage.LastUpdated} vs {indexedPackage.LastUpdated}). downloading..."
-                            API.SaveAndCachePackage(
+                            Preview.SaveAndCachePackage(
                                 cache = cache,
                                 indexedPackage = updatedIndexPackage,
                                 ?Token = Token
@@ -184,7 +268,7 @@ type API =
 
                 |None -> 
                     // not cached -> download and cache
-                    API.SaveAndCachePackage(
+                    Preview.SaveAndCachePackage(
                         cache = cache,
                         indexedPackage = indexedPackage,
                         ?Token = Token
@@ -192,6 +276,7 @@ type API =
         else    
             // package does not exists on the local index
             Error (PackageNotFound packageName)
+
 
     static member UninstallPackage(
         cache: PackageCache,
@@ -223,7 +308,7 @@ type API =
                 Error (IOError e.Message)
 
         | Some semver ->
-            if verbose then printfn $"uninstalling all package versions of {packageName}..."
+            if verbose then printfn $"uninstalling {packageName}@{semver}..."
 
             match PackageCache.tryGetPackage packageName semver cache with
             | Some p -> 
@@ -243,31 +328,7 @@ type API =
                 if verbose then printfn $"package {packageName} is not installed."
                 Error (PackageNotInstalled packageName)
 
-
-    static member ListCachedPackages(
-        cache: PackageCache,
-        ?Verbose: bool
-    ) =
-        try
-            cache 
-            |> PackageCache.getAllPackages
-            |> Ok
-        
-        with e ->
-            Error e.Message
-
-    static member ListIndexedPackages(
-        config: Config,
-        ?Verbose: bool
-    ) =
-        try
-            config.PackageIndex
-            |> Array.toList
-            |> Ok
-        
-        with e ->
-            Error e.Message
-
+/// Top-level API functions using the AVPR API (avpr.nfdi4plants.org) as package source
 type AVPR =
     
     static member SaveAndCachePackage (
@@ -395,15 +456,3 @@ type AVPR =
             | None -> 
                 if verbose then printfn $"package {packageName} is not installed."
                 Error (PackageNotInstalled packageName)
-
-    static member ListCachedPackages(
-        cache: PackageCache,
-        ?Verbose: bool
-    ) =
-        try
-            cache 
-            |> PackageCache.getAllPackages
-            |> Ok
-        
-        with e ->
-            Error e.Message

--- a/src/ARCValidationPackages/TopLevelAPI.fs
+++ b/src/ARCValidationPackages/TopLevelAPI.fs
@@ -290,7 +290,9 @@ type AVPR =
                     
             let metadata = validationPackage.toValidationPackageMetadata()
             let package = CachedValidationPackage.ofPackageMetadata(metadata, ?CacheFolder = CacheFolder)
-            
+
+            File.WriteAllBytes(package.LocalPath, validationPackage.PackageContent)
+
             cache
             |> PackageCache.addPackage package
             |> PackageCache.write(cacheFolder)

--- a/src/arc-validate/APIs/PackageAPI.fs
+++ b/src/arc-validate/APIs/PackageAPI.fs
@@ -46,7 +46,7 @@ type PackageAPI =
         | Ok (config, avprCache, previewCache) -> 
         
             let packageName = args.TryGetResult(PackageInstallArgs.Package).Value
-            let version = args.TryGetResult(PackageInstallArgs.PackageVersion)
+            let version = args.TryGetResult(PackageInstallArgs.Version)
             if isRelease then
                 match (AVPR.InstallPackage(avprCache, packageName, ?SemVer = version, ?Verbose = Verbose)) with
                 | Ok msg ->

--- a/src/arc-validate/APIs/PackageAPI.fs
+++ b/src/arc-validate/APIs/PackageAPI.fs
@@ -36,7 +36,7 @@ type PackageAPI =
         ?Verbose: bool,
         ?Token: string
     ) = 
-        match ARCValidationPackages.API.GetSyncedConfigAndCache(?Token = Token) with
+        match ARCValidationPackages.API.GetSyncedConfigAndCache(false, ?Token = Token) with
         | Error e -> 
             PackageAPI.printGetSyncedConfigAndCacheError e
             ExitCode.InternalError
@@ -61,7 +61,7 @@ type PackageAPI =
         ?Token: string
     ) = 
 
-        match ARCValidationPackages.API.GetSyncedConfigAndCache(?Token = Token) with
+        match ARCValidationPackages.API.GetSyncedConfigAndCache(false, ?Token = Token) with
         | Error e -> 
             PackageAPI.printGetSyncedConfigAndCacheError e
             ExitCode.InternalError
@@ -91,7 +91,7 @@ type PackageAPI =
         ?Token: string
     ) = 
 
-        match ARCValidationPackages.API.GetSyncedConfigAndCache(?Token = Token) with
+        match ARCValidationPackages.API.GetSyncedConfigAndCache(false, ?Token = Token) with
         | Error e -> 
             PackageAPI.printGetSyncedConfigAndCacheError e
             ExitCode.InternalError
@@ -160,7 +160,7 @@ type PackageAPI =
         ?Verbose: bool,
         ?Token: string
     ) = 
-        match ARCValidationPackages.API.GetSyncedConfigAndCache(?Token = Token) with
+        match ARCValidationPackages.API.GetSyncedConfigAndCache(false, ?Token = Token) with
         | Error e -> 
             PackageAPI.printGetSyncedConfigAndCacheError e
             ExitCode.InternalError

--- a/src/arc-validate/APIs/ValidateAPI.fs
+++ b/src/arc-validate/APIs/ValidateAPI.fs
@@ -97,7 +97,7 @@ module ValidateAPI =
                     AnsiConsole.Write(TextPath(Path.GetFullPath(root)))
                     AnsiConsole.MarkupLine("")
                 
-                match ARCValidationPackages.API.GetSyncedConfigAndCache(?Token = token) with
+                match ARCValidationPackages.API.GetSyncedConfigAndCache(false, ?Token = token) with
                 | Error e -> 
                     PackageAPI.printGetSyncedConfigAndCacheError e
                     exitCode <- ExitCode.InternalError

--- a/src/arc-validate/APIs/ValidateAPI.fs
+++ b/src/arc-validate/APIs/ValidateAPI.fs
@@ -92,7 +92,9 @@ module ValidateAPI =
 
             let isRelease = args.TryGetResult(ValidateArgs.Preview).IsSome |> not
 
-            status.Start($"Performing validation against the {packageName} package", fun ctx ->
+            let packageMessagePrefix = if isRelease then "" else "preview "
+
+            status.Start($"Performing validation against the {packageMessagePrefix}{packageName} package", fun ctx ->
 
                 if verbose then
                     AnsiConsole.MarkupLine("LOG: Running in:")

--- a/src/arc-validate/APIs/ValidateAPI.fs
+++ b/src/arc-validate/APIs/ValidateAPI.fs
@@ -36,7 +36,7 @@ module ValidateAPI =
             args.TryGetResult(Package)
 
         let version = 
-            args.TryGetResult(PackageVersion)
+            args.TryGetResult(Package_Version)
 
         match package with
 

--- a/src/arc-validate/CLIArgs/PackageArgs.fs
+++ b/src/arc-validate/CLIArgs/PackageArgs.fs
@@ -24,13 +24,3 @@ type PackageUninstallArgs =
             | Package _        -> "name of the validation package to uninstall"
             | PackageVersion _        -> "version of the validation package to uninstall. If no version is specified, all versions will be uninstalled."
             | Preview       -> "uninstall the preview version of the package"
-
-type PackageListArgs = 
-    | [<AltCommandLine("-i"); Unique>] Installed
-    | [<AltCommandLine("-c"); Unique>] Indexed
-
-    interface IArgParserTemplate with
-        member s.Usage =
-            match s with
-            | Installed     -> "list installed packages from the package cache"
-            | Indexed       -> "list indexed packages from the cached package index"

--- a/src/arc-validate/CLIArgs/PackageArgs.fs
+++ b/src/arc-validate/CLIArgs/PackageArgs.fs
@@ -24,3 +24,10 @@ type PackageUninstallArgs =
             | Package _        -> "name of the validation package to uninstall"
             | PackageVersion _        -> "version of the validation package to uninstall. If no version is specified, all versions will be uninstalled."
             | Preview       -> "uninstall the preview version of the package"
+
+type PackageListArgs = 
+    | [<Unique>] Include_Indexed 
+    interface IArgParserTemplate with
+        member s.Usage =
+            match s with
+            | Include_Indexed -> "include packages indexed (but not installed!) from the local copy of the preview index"

--- a/src/arc-validate/CLIArgs/PackageArgs.fs
+++ b/src/arc-validate/CLIArgs/PackageArgs.fs
@@ -3,14 +3,14 @@ open Argu
 
 type PackageInstallArgs = 
     | [<ExactlyOnce; MainCommand>] Package of package_name:string
-    | [<Unique; AltCommandLine("-pv")>] PackageVersion of package_version:string
-    | [<Unique; AltCommandLine("-pr")>] Preview
+    | [<Unique; AltCommandLine("-v")>] Version of version:string
+    | [<Unique>] Preview
 
     interface IArgParserTemplate with
         member s.Usage =
             match s with
             | Package _        -> "name of the validation package to install"
-            | PackageVersion _        -> "version of the validation package to install. If no version is specified, the latest version will be installed."
+            | Version _        -> "version of the validation package to install. If no version is specified, the latest version will be installed."
             | Preview        -> "install the preview version of the package"
 
 type PackageUninstallArgs = 

--- a/src/arc-validate/CLIArgs/PackageArgs.fs
+++ b/src/arc-validate/CLIArgs/PackageArgs.fs
@@ -4,22 +4,26 @@ open Argu
 type PackageInstallArgs = 
     | [<ExactlyOnce; MainCommand>] Package of package_name:string
     | [<Unique; AltCommandLine("-pv")>] PackageVersion of package_version:string
+    | [<Unique; AltCommandLine("-pr")>] Preview
 
     interface IArgParserTemplate with
         member s.Usage =
             match s with
             | Package _        -> "name of the validation package to install"
             | PackageVersion _        -> "version of the validation package to install. If no version is specified, the latest version will be installed."
+            | Preview        -> "install the preview version of the package"
 
 type PackageUninstallArgs = 
     | [<ExactlyOnce; MainCommand>] Package of package_name:string
     | [<Unique; AltCommandLine("-pv")>] PackageVersion of package_version:string
+    | [<Unique; AltCommandLine("-pr")>] Preview
 
     interface IArgParserTemplate with
         member s.Usage =
             match s with
             | Package _        -> "name of the validation package to uninstall"
             | PackageVersion _        -> "version of the validation package to uninstall. If no version is specified, all versions will be uninstalled."
+            | Preview       -> "uninstall the preview version of the package"
 
 type PackageListArgs = 
     | [<AltCommandLine("-i"); Unique>] Installed

--- a/src/arc-validate/CLIArgs/ValidateArgs.fs
+++ b/src/arc-validate/CLIArgs/ValidateArgs.fs
@@ -6,6 +6,7 @@ type ValidateArgs =
     | [<AltCommandLine("-o")>] Out_Directory of path:string
     | [<AltCommandLine("-p")>] Package of package_name:string
     | [<AltCommandLine("-pv")>] PackageVersion of package_version:string
+    | [<AltCommandLine("-pr")>] Preview
 
     interface IArgParserTemplate with
         member s.Usage =
@@ -14,3 +15,4 @@ type ValidateArgs =
             | ARC_Directory _ -> "Optional. Specify a directory that contains the arc to convert. Default: content of the ARC_PATH environment variable. If ARC_PATH is not set: current directory."
             | Package _       -> "Optional. Specify a validation package to use on top of the default validation for invenio export. Default: no package is used, only structural validation for invenio export."
             | PackageVersion _ -> "Optional. Specify a version of the validation package to use. If no version is specified, the latest version will be used."
+            | Preview         -> "Optional. Use the preview version of the package."

--- a/src/arc-validate/CLIArgs/ValidateArgs.fs
+++ b/src/arc-validate/CLIArgs/ValidateArgs.fs
@@ -2,11 +2,11 @@
 open Argu
 
 type ValidateArgs = 
-    | [<AltCommandLine("-i")>] ARC_Directory of path:string
-    | [<AltCommandLine("-o")>] Out_Directory of path:string
-    | [<AltCommandLine("-p")>] Package of package_name:string
-    | [<AltCommandLine("-pv")>] PackageVersion of package_version:string
-    | [<AltCommandLine("-pr")>] Preview
+    | [<Unique; AltCommandLine("-i")>] ARC_Directory of path:string
+    | [<Unique; AltCommandLine("-o")>] Out_Directory of path:string
+    | [<Unique; AltCommandLine("-p")>] Package of package_name:string
+    | [<Unique; AltCommandLine("-v")>] Package_Version of package_version:string
+    | [<Unique>] Preview
 
     interface IArgParserTemplate with
         member s.Usage =
@@ -14,5 +14,5 @@ type ValidateArgs =
             | Out_Directory _ -> "Optional. Specify a output directory for the test results file (arc-validate-results.xml). Default: file gets written to the arc root folder."
             | ARC_Directory _ -> "Optional. Specify a directory that contains the arc to convert. Default: content of the ARC_PATH environment variable. If ARC_PATH is not set: current directory."
             | Package _       -> "Optional. Specify a validation package to use on top of the default validation for invenio export. Default: no package is used, only structural validation for invenio export."
-            | PackageVersion _ -> "Optional. Specify a version of the validation package to use. If no version is specified, the latest version will be used."
+            | Package_Version _ -> "Optional. Specify a version of the validation package to use. If no version is specified, the latest version will be used."
             | Preview         -> "Optional. Use the preview version of the package."

--- a/src/arc-validate/CommandHandling.fs
+++ b/src/arc-validate/CommandHandling.fs
@@ -14,9 +14,9 @@ module CommandHandling =
         | UnInstall args    -> 
             if verbose then printfn "Command: uninstall"
             PackageAPI.Uninstall(args, verbose)
-        | List args         -> 
+        | List -> 
             if verbose then printfn "Command: list"
-            PackageAPI.List(args, verbose, ?Token = token)
+            PackageAPI.List(verbose, ?Token = token)
         | Update_Index      -> 
             if verbose then printfn "Command: update-index"
             PackageAPI.UpdateIndex(verbose, ?Token = token)

--- a/src/arc-validate/CommandHandling.fs
+++ b/src/arc-validate/CommandHandling.fs
@@ -14,9 +14,9 @@ module CommandHandling =
         | UnInstall args    -> 
             if verbose then printfn "Command: uninstall"
             PackageAPI.Uninstall(args, verbose)
-        | List -> 
+        | List args -> 
             if verbose then printfn "Command: list"
-            PackageAPI.List(verbose, ?Token = token)
+            PackageAPI.List(args, verbose, ?Token = token)
         | Update_Index      -> 
             if verbose then printfn "Command: update-index"
             PackageAPI.UpdateIndex(verbose, ?Token = token)

--- a/src/arc-validate/Commands/ARCValidateCommand.fs
+++ b/src/arc-validate/Commands/ARCValidateCommand.fs
@@ -6,14 +6,14 @@ open Argu
 [<HelpFlags([|"--help"; "-h"|])>]
 type ARCValidateCommand =
     // Parameters
-    | [<AltCommandLine("-v")>] Verbose    
-    | [<AltCommandLine("-t")>] Token of string
+    | [<Unique>] Verbose    
+    | [<Unique; AltCommandLine("-t")>] Token of string
 
     //Commands
-    | [<CliPrefix(CliPrefix.None); AltCommandLine("v")>] Validate of ParseResults<ValidateArgs>
+    | [<Unique; CliPrefix(CliPrefix.None); AltCommandLine("v")>] Validate of ParseResults<ValidateArgs>
 
     // SubCommands
-    | [<CliPrefix(CliPrefix.None); AltCommandLine("p")>] Package of ParseResults<PackageCommand>
+    | [<Unique; CliPrefix(CliPrefix.None); AltCommandLine("p")>] Package of ParseResults<PackageCommand>
 
     interface IArgParserTemplate with
         member s.Usage =

--- a/src/arc-validate/Commands/PackageCommand.fs
+++ b/src/arc-validate/Commands/PackageCommand.fs
@@ -6,7 +6,7 @@ open Argu
 type PackageCommand =
     | [<CliPrefix(CliPrefix.None); AltCommandLine("i")>] Install of ParseResults<PackageInstallArgs>
     | [<CliPrefix(CliPrefix.None); AltCommandLine("u")>] UnInstall of ParseResults<PackageUninstallArgs>
-    | [<CliPrefix(CliPrefix.None); AltCommandLine("l")>] List
+    | [<CliPrefix(CliPrefix.None); AltCommandLine("l")>] List of ParseResults<PackageListArgs>
     | [<CliPrefix(CliPrefix.None); AltCommandLine("c"); SubCommand()>] Update_Index
 
     interface IArgParserTemplate with
@@ -14,5 +14,5 @@ type PackageCommand =
             match s with
             | Install _     -> "install valiation packages"
             | UnInstall _   -> "uninstall valiation packages"
-            | List          -> "list packages from available soures"
-            | Update_Index   -> "update the locally chached package index"
+            | List _        -> "list packages from available soures"
+            | Update_Index  -> "update the locally chached package index"

--- a/src/arc-validate/Commands/PackageCommand.fs
+++ b/src/arc-validate/Commands/PackageCommand.fs
@@ -6,7 +6,7 @@ open Argu
 type PackageCommand =
     | [<CliPrefix(CliPrefix.None); AltCommandLine("i")>] Install of ParseResults<PackageInstallArgs>
     | [<CliPrefix(CliPrefix.None); AltCommandLine("u")>] UnInstall of ParseResults<PackageUninstallArgs>
-    | [<CliPrefix(CliPrefix.None); AltCommandLine("l")>] List of ParseResults<PackageListArgs>
+    | [<CliPrefix(CliPrefix.None); AltCommandLine("l")>] List
     | [<CliPrefix(CliPrefix.None); AltCommandLine("c"); SubCommand()>] Update_Index
 
     interface IArgParserTemplate with
@@ -14,5 +14,5 @@ type PackageCommand =
             match s with
             | Install _     -> "install valiation packages"
             | UnInstall _   -> "uninstall valiation packages"
-            | List _        -> "list packages from available soures"
+            | List          -> "list packages from available soures"
             | Update_Index   -> "update the locally chached package index"

--- a/tests/ARCValidationPackages.Tests/ARCValidationPackages.Tests.fsproj
+++ b/tests/ARCValidationPackages.Tests/ARCValidationPackages.Tests.fsproj
@@ -12,6 +12,7 @@
     <Compile Include="ReferenceObjects.fs" />
     <Compile Include="DefaultsTests.fs" />
     <Compile Include="GitHubAPITests.fs" />
+    <Compile Include="AVPRAPITests.fs" />
     <Compile Include="ARCValidationPackageTests.fs" />
     <Compile Include="PackageCacheTests.fs" />
     <Compile Include="ConfigTests.fs" />

--- a/tests/ARCValidationPackages.Tests/AVPRAPITests.fs
+++ b/tests/ARCValidationPackages.Tests/AVPRAPITests.fs
@@ -11,7 +11,7 @@ open TestUtils
 let token = get_gh_api_token()
 
 [<Tests>]
-let ``GitHubAPI tests`` = 
+let ``AVPRAPI tests`` = 
     testList "AVPR API tests" [
         test "getRepositoryContent returns correct content" {
             let vp = AVPR.api.GetPackageByNameAndVersion "test" "3.0.0"
@@ -27,23 +27,13 @@ let ``GitHubAPI tests`` =
             let indexedPackages = AVPR.api.GetAllPackages()
             Expect.isTrue (indexedPackages |> Array.exists (fun package -> package.Name = "test")) "package index did not contain test script"
         }
-        test "getScriptContent terminates" {
-            GitHubAPI.downloadPackageScript(
-                "StagingArea/test/test@1.0.0.fsx",
-                ?Token = token
-            )
-            |> ignore
-        }
         test "getScriptContent returns correct content" {
             Expect.equal 
                 (
-                    GitHubAPI.downloadPackageScript(
-                        "StagingArea/test/test@1.0.0.fsx",
-                        ?Token = token
-                    )
+                    AVPR.api.downloadPackageScript( "test", "3.0.0")
                     |> fun content -> content.ReplaceLineEndings()
                 )
-                ReferenceObjects.testScriptContent
+                ReferenceObjects.testScriptContentAVPR
                 "script content was not correct"
         }
     ]

--- a/tests/ARCValidationPackages.Tests/AVPRAPITests.fs
+++ b/tests/ARCValidationPackages.Tests/AVPRAPITests.fs
@@ -1,0 +1,49 @@
+﻿module AVPRAPITests
+
+open Expecto
+open ARCValidationPackages
+open FsHttp
+open System
+open System.Text
+open Common.TestUtils
+open TestUtils
+
+let token = get_gh_api_token()
+
+[<Tests>]
+let ``GitHubAPI tests`` = 
+    testList "AVPR API tests" [
+        test "getRepositoryContent returns correct content" {
+            let vp = AVPR.api.GetPackageByNameAndVersion "test" "3.0.0"
+            let script =
+                vp.PackageContent
+                |> Encoding.UTF8.GetString
+            Expect.equal 
+                script
+                ReferenceObjects.testScriptContentAVPR
+                $"repository content was not correct{System.Environment.NewLine}{script}"
+        }
+        test "getPackageIndex contains test script" {
+            let indexedPackages = AVPR.api.GetAllPackages()
+            Expect.isTrue (indexedPackages |> Array.exists (fun package -> package.Name = "test")) "package index did not contain test script"
+        }
+        test "getScriptContent terminates" {
+            GitHubAPI.downloadPackageScript(
+                "StagingArea/test/test@1.0.0.fsx",
+                ?Token = token
+            )
+            |> ignore
+        }
+        test "getScriptContent returns correct content" {
+            Expect.equal 
+                (
+                    GitHubAPI.downloadPackageScript(
+                        "StagingArea/test/test@1.0.0.fsx",
+                        ?Token = token
+                    )
+                    |> fun content -> content.ReplaceLineEndings()
+                )
+                ReferenceObjects.testScriptContent
+                "script content was not correct"
+        }
+    ]

--- a/tests/ARCValidationPackages.Tests/AVPRAPITests.fs
+++ b/tests/ARCValidationPackages.Tests/AVPRAPITests.fs
@@ -19,7 +19,7 @@ let ``GitHubAPI tests`` =
                 vp.PackageContent
                 |> Encoding.UTF8.GetString
             Expect.equal 
-                script
+                (script.ReplaceLineEndings())
                 ReferenceObjects.testScriptContentAVPR
                 $"repository content was not correct{System.Environment.NewLine}{script}"
         }

--- a/tests/ARCValidationPackages.Tests/ConfigTests.fs
+++ b/tests/ARCValidationPackages.Tests/ConfigTests.fs
@@ -19,7 +19,8 @@ let ``Config tests`` =
                     packageIndex = testPackageIndex,
                     indexLastUpdated = testDate1,
                     configFilePath = Defaults.CONFIG_FILE_PATH(),
-                    packageCacheFolder = Defaults.PACKAGE_CACHE_FOLDER_PREVIEW()
+                    packageCacheFolderPreview = Defaults.PACKAGE_CACHE_FOLDER_PREVIEW(),
+                    packageCacheFolderRelease = Defaults.PACKAGE_CACHE_FOLDER_RELEASE()
                 )
 
             test "config file path is correct" {
@@ -28,11 +29,17 @@ let ``Config tests`` =
                     expected_config_file_path
                     "config file path is not correct"
             } 
-            test "package cache folder is correct" {
+            test "package cache preview folder is correct" {
                 Expect.equal 
-                    (testConfig.PackageCacheFolder) 
+                    (testConfig.PackageCacheFolderPreview) 
                     expected_package_cache_folder_path_preview
-                    "package cache folder path is not correct"
+                    "package cache preview folder path is not correct"
+            } 
+            test "package cache release folder is correct" {
+                Expect.equal 
+                    (testConfig.PackageCacheFolderRelease) 
+                    expected_package_cache_folder_path_release
+                    "package cache release folder path is not correct"
             } 
             test "config folder path is correct" {
                 Expect.equal 
@@ -45,10 +52,15 @@ let ``Config tests`` =
                     (Path.GetDirectoryName (testConfig.ConfigFilePath) |> Directory.Exists)
                     "config file path does not exist"
             } 
-            test "package cache folder exists" {
+            test "package cache preview folder exists" {
                 Expect.isTrue 
-                    (Directory.Exists(testConfig.PackageCacheFolder))
-                    "package cache folder path does not exist"
+                    (Directory.Exists(testConfig.PackageCacheFolderPreview))
+                    "package cache preview folder path does not exist"
+            }
+            test "package cache release folder exists" {
+                Expect.isTrue 
+                    (Directory.Exists(testConfig.PackageCacheFolderRelease))
+                    "package cache release folder path does not exist"
             } 
             test "can write json" {
                 resetConfigEnvironment()

--- a/tests/ARCValidationPackages.Tests/DefaultsTests.fs
+++ b/tests/ARCValidationPackages.Tests/DefaultsTests.fs
@@ -31,23 +31,39 @@ let ``Defaults tests`` =
                     expected_config_file_path
                     "config file path is not correct"
             }
-            test "package cache folder path is correct" {
+            test "package cache preview folder path is correct" {
                 Expect.equal 
                     (Defaults.PACKAGE_CACHE_FOLDER_PREVIEW()) 
                     expected_package_cache_folder_path_preview
-                    "package cache folder path is not correct"
+                    "package cache preview folder path is not correct"
             }
-            test "package cache folder path exists" {
+            test "package cache release folder path is correct" {
+                Expect.equal 
+                    (Defaults.PACKAGE_CACHE_FOLDER_RELEASE()) 
+                    expected_package_cache_folder_path_release
+                    "package cache release folder path is not correct"
+            }
+            test "package cache preview folder path exists" {
                 Expect.isTrue 
                     (Directory.Exists(expected_package_cache_folder_path_preview))
-                    "package cache folder path does not exist"
+                    "package cache preview folder path does not exist"
             }
-            test "package cache file path is correct" {
+            test "package cache release folder path exists" {
+                Expect.isTrue 
+                    (Directory.Exists(expected_package_cache_folder_path_release))
+                    "package cache release folder path does not exist"
+            }
+            test "package cache preview file path is correct" {
                 Expect.equal 
                     (Defaults.PACKAGE_CACHE_FILE_PATH_PREVIEW()) 
                     expected_package_cache_file_path_preview
-                    "config file path is not correct"
+                    "config file preview path is not correct"
             }
-
+            test "package cache release file path is correct" {
+                Expect.equal 
+                    (Defaults.PACKAGE_CACHE_FILE_PATH_RELEASE()) 
+                    expected_package_cache_file_path_release
+                    "config file release path is not correct"
+            }
         ]
     )

--- a/tests/ARCValidationPackages.Tests/PackageCacheTests.fs
+++ b/tests/ARCValidationPackages.Tests/PackageCacheTests.fs
@@ -63,7 +63,7 @@ let tests =
 
         test "can write json preview" {
             deleteDefaultPackageCache() // make sure any cached file is deleted before testing that it can be written
-            testPackageCache1 |> PackageCache.write()
+            testPackageCache1 |> PackageCache.write(Defaults.PACKAGE_CACHE_FOLDER_PREVIEW())
             Expect.isTrue (File.Exists(expected_package_cache_file_path_preview)) "package cache file was not created"
         } |> testSequenced
 
@@ -75,7 +75,7 @@ let tests =
 
         test "can read json preview" {
             Expect.packageCacheEqual 
-                (PackageCache.read())
+                (PackageCache.read(Defaults.PACKAGE_CACHE_FOLDER_PREVIEW()))
                 testPackageCache1
         } |> testSequenced
 

--- a/tests/ARCValidationPackages.Tests/PackageCacheTests.fs
+++ b/tests/ARCValidationPackages.Tests/PackageCacheTests.fs
@@ -8,6 +8,7 @@ open TestUtils
 open Common.TestUtils
 open TestUtils
 open System.Collections.Generic
+
 [<Tests>]
 let tests =
     testSequenced (testList "PackageCache tests" [

--- a/tests/ARCValidationPackages.Tests/PackageCacheTests.fs
+++ b/tests/ARCValidationPackages.Tests/PackageCacheTests.fs
@@ -68,7 +68,7 @@ let tests =
         } |> testSequenced
 
         test "can write json release" {
-            deleteDefaultPackageCache() // make sure any cached file is deleted before testing that it can be written
+            //deleteDefaultPackageCache() // make sure any cached file is deleted before testing that it can be written
             testPackageCache1 |> PackageCache.write(Defaults.PACKAGE_CACHE_FOLDER_RELEASE())
             Expect.isTrue (File.Exists(expected_package_cache_file_path_release)) "package cache file was not created"
         } |> testSequenced

--- a/tests/ARCValidationPackages.Tests/PackageCacheTests.fs
+++ b/tests/ARCValidationPackages.Tests/PackageCacheTests.fs
@@ -75,7 +75,7 @@ let tests =
 
         test "can read json preview" {
             Expect.packageCacheEqual 
-                (PackageCache.read(Defaults.PACKAGE_CACHE_FOLDER_PREVIEW()))
+                (PackageCache.read(Defaults.PACKAGE_CACHE_FILE_PATH_PREVIEW()))
                 testPackageCache1
         } |> testSequenced
 

--- a/tests/ARCValidationPackages.Tests/PackageCacheTests.fs
+++ b/tests/ARCValidationPackages.Tests/PackageCacheTests.fs
@@ -61,15 +61,27 @@ let tests =
                 testPackageCache2
         } |> testSequenced
 
-        test "can write json" {
+        test "can write json preview" {
             deleteDefaultPackageCache() // make sure any cached file is deleted before testing that it can be written
             testPackageCache1 |> PackageCache.write()
             Expect.isTrue (File.Exists(expected_package_cache_file_path_preview)) "package cache file was not created"
         } |> testSequenced
 
-        test "can read json" {
+        test "can write json release" {
+            deleteDefaultPackageCache() // make sure any cached file is deleted before testing that it can be written
+            testPackageCache1 |> PackageCache.write(Defaults.PACKAGE_CACHE_FOLDER_RELEASE())
+            Expect.isTrue (File.Exists(expected_package_cache_file_path_release)) "package cache file was not created"
+        } |> testSequenced
+
+        test "can read json preview" {
             Expect.packageCacheEqual 
                 (PackageCache.read())
+                testPackageCache1
+        } |> testSequenced
+
+        test "can read json release" {
+            Expect.packageCacheEqual 
+                (PackageCache.read(Defaults.PACKAGE_CACHE_FILE_PATH_RELEASE()))
                 testPackageCache1
         } |> testSequenced
 

--- a/tests/ARCValidationPackages.Tests/ReferenceObjects.fs
+++ b/tests/ARCValidationPackages.Tests/ReferenceObjects.fs
@@ -84,44 +84,23 @@ let testValidationPackage3FullMetadata =
             0,
             Publish = true,
             Authors = [|
-                let author1 = new Author()
-                let author2 = new Author()
-                (
-                    author1.FullName <- "John Doe"
-                    author1.Email <- "j@d.com"
-                    author1.Affiliation <- "University of Nowhere"
-                    author1.AffiliationLink <- "https://nowhere.edu"
+                Author.create(
+                    fullName = "John Doe",
+                    email = "j@d.com",
+                    Affiliation = "University of Nowhere",
+                    AffiliationLink = "https://nowhere.edu"
                 )
-                (
-                    author2.FullName <- "Jane Doe"
-                    author2.Email <- "jj@d.com"
-                    author2.Affiliation <- "University of Somewhere"
-                    author2.AffiliationLink <- "https://somewhere.edu"
+                Author.create(
+                    fullName = "Jane Doe",
+                    email = "jj@d.com",
+                    Affiliation = "University of Somewhere",
+                    AffiliationLink = "https://somewhere.edu"
                 )
-                author1; author2
-                //Author.create(
-                //    fullName = "John Doe",
-                //    email = "j@d.com",
-                //    Affiliation = "University of Nowhere",
-                //    AffiliationLink = "https://nowhere.edu"
-                //)
-                //Author.create(
-                //    fullName = "Jane Doe",
-                //    email = "jj@d.com",
-                //    Affiliation = "University of Somewhere",
-                //    AffiliationLink = "https://somewhere.edu"
-                //)
             |],
             Tags = [|
-                let annotation1 = new OntologyAnnotation ()
-                let annotation2 = new OntologyAnnotation ()
-                let annotation3 = new OntologyAnnotation ()
-                annotation1.Name <- "validation"
-                annotation2.Name <- "my-package"
-                annotation3.Name <- "thing"
-                annotation1
-                annotation2
-                annotation3
+                OntologyAnnotation.create("validation")
+                OntologyAnnotation.create("my-package")
+                OntologyAnnotation.create("thing")
             |],
             ReleaseNotes = "add authors and tags for further testing"
         )

--- a/tests/ARCValidationPackages.Tests/ReferenceObjects.fs
+++ b/tests/ARCValidationPackages.Tests/ReferenceObjects.fs
@@ -54,6 +54,50 @@ validationCases
     packageName = "test"
 )"""                        .ReplaceLineEndings()
 
+let testScriptContentAVPR = """(*
+---
+Name: test
+MajorVersion: 3
+MinorVersion: 0
+PatchVersion: 0
+Publish: true
+Summary: this package is here for testing purposes only.
+Description: this package is here for testing purposes only.
+Authors:
+  - FullName: John Doe
+    Email: j@d.com
+    Affiliation: University of Nowhere
+    AffiliationLink: https://nowhere.edu
+  - FullName: Jane Doe
+    Email: jj@d.com
+    Affiliation: University of Somewhere
+    AffiliationLink: https://somewhere.edu
+Tags:
+  - Name: validation
+  - Name: my-package
+  - Name: thing
+ReleaseNotes: "add authors and tags for further testing"
+---
+*)
+ 
+// this file is intended for testing purposes only.
+printfn "If you can read this in your console, you successfully executed test package v3.0.0!" 
+
+#r "nuget: ARCExpect, 1.0.1"
+
+open ARCExpect
+open Expecto
+
+let validationCases = testList "test" [
+    test "yes" {Expect.equal 1 1 "yes"}
+]
+
+validationCases
+|> Execute.ValidationPipeline(
+    basePath = System.Environment.CurrentDirectory,
+    packageName = "test"
+)"""                            .ReplaceLineEndings()
+
 let testValidationPackage1 =
     CachedValidationPackage.create(
         "test@1.0.0.fsx",

--- a/tests/ARCValidationPackages.Tests/TestUtils.fs
+++ b/tests/ARCValidationPackages.Tests/TestUtils.fs
@@ -76,3 +76,7 @@ module Fixtures =
     //    let freshConfig, freshCache = API.GetSyncedConfigAndCache(?Token = token) |> Result.okValue
     //    let updatedCache = API.SaveAndCachePackage(freshConfig, freshCache, package) |> Result.okValue
     //    updatedCache
+
+module AVPR =
+    
+    let api = new AVPRAPI()

--- a/tests/ARCValidationPackages.Tests/TestUtils.fs
+++ b/tests/ARCValidationPackages.Tests/TestUtils.fs
@@ -64,7 +64,7 @@ module Fixtures =
 
     let withFreshConfigAndCache (token:string option) (f: Config * PackageCache -> unit) () =
         resetConfigEnvironment()
-        let freshConfig, freshCache = API.GetSyncedConfigAndCache(?Token = token) |> Result.okValue
+        let freshConfig, freshCache = API.GetSyncedConfigAndCache(false, ?Token = token) |> Result.okValue
         f (freshConfig, freshCache)
 
     //let saveAndCachePackage (token:string option) (package:Package) =

--- a/tests/ARCValidationPackages.Tests/TestUtils.fs
+++ b/tests/ARCValidationPackages.Tests/TestUtils.fs
@@ -62,9 +62,14 @@ module Result =
 
 module Fixtures =
 
-    let withFreshConfigAndCache (token:string option) (f: Config * PackageCache -> unit) () =
+    let withFreshConfigAndCachePreview (token:string option) (f: Config * PackageCache -> unit) () =
         resetConfigEnvironment()
         let freshConfig, freshCache = API.GetSyncedConfigAndCache(false, ?Token = token) |> Result.okValue
+        f (freshConfig, freshCache)
+
+    let withFreshConfigAndCacheRelease (f: Config * PackageCache -> unit) () =
+        resetConfigEnvironment()
+        let freshConfig, freshCache = API.GetSyncedConfigAndCache(true) |> Result.okValue
         f (freshConfig, freshCache)
 
     //let saveAndCachePackage (token:string option) (package:Package) =

--- a/tests/ARCValidationPackages.Tests/TestUtils.fs
+++ b/tests/ARCValidationPackages.Tests/TestUtils.fs
@@ -62,15 +62,10 @@ module Result =
 
 module Fixtures =
 
-    let withFreshConfigAndCachePreview (token:string option) (f: Config * PackageCache -> unit) () =
+    let withFreshConfigAndCaches (token:string option) (f: Config * PackageCache * PackageCache -> unit) () =
         resetConfigEnvironment()
-        let freshConfig, freshCache = API.GetSyncedConfigAndCache(false, ?Token = token) |> Result.okValue
-        f (freshConfig, freshCache)
-
-    let withFreshConfigAndCacheRelease (f: Config * PackageCache -> unit) () =
-        resetConfigEnvironment()
-        let freshConfig, freshCache = API.GetSyncedConfigAndCache(true) |> Result.okValue
-        f (freshConfig, freshCache)
+        let freshConfig, freshAVPRCache, freshPreviewCache = API.Common.GetSyncedConfigAndCache(?Token = token) |> Result.okValue
+        f (freshConfig, freshAVPRCache, freshPreviewCache)
 
     //let saveAndCachePackage (token:string option) (package:Package) =
     //    let freshConfig, freshCache = API.GetSyncedConfigAndCache(?Token = token) |> Result.okValue

--- a/tests/ARCValidationPackages.Tests/TestUtils.fs
+++ b/tests/ARCValidationPackages.Tests/TestUtils.fs
@@ -9,6 +9,14 @@ open Common.TestUtils
 module Expect =
     open Expecto
 
+    let packageCacheContainsPackage (packageName: string) (packageVersion:string) (packageCache:PackageCache) =
+        Expect.isTrue (packageCache.ContainsKey(packageName)) "package cache did not contain any version of the package"
+        Expect.isTrue (packageCache.[packageName].ContainsKey(packageVersion)) "package cache did not contain the specific version of the package"
+
+    let packageCacheDoesNotContainPackage (packageName: string) (packageVersion:string) (packageCache:PackageCache) =
+        Expect.isFalse (packageCache.ContainsKey(packageName)) "package cache did not contain any version of the package"
+        Expect.isFalse (packageCache.[packageName].ContainsKey(packageVersion)) "package cache did not contain the specific version of the package"
+
     let packageCacheEqual (actual:PackageCache) (expected:PackageCache) =
         let actualKeysSorted, expectedKeysSorted = (actual.Keys |> Seq.sort), (expected.Keys |> Seq.sort)
         let countIsEqual = actual.Count = expected.Count

--- a/tests/ARCValidationPackages.Tests/TopLevelAPITests.fs
+++ b/tests/ARCValidationPackages.Tests/TopLevelAPITests.fs
@@ -21,7 +21,7 @@ let ``Toplevel API tests`` =
 
         testSequenced (testList "getSyncedConfigAndCache" [
 
-            yield! testFixture (Fixtures.withFreshConfigAndCache (get_gh_api_token())) [
+            yield! testFixture (Fixtures.withFreshConfigAndCachePreview (get_gh_api_token())) [
                 "Fresh config filepath",
                     fun (freshConfig, _) ->
                         Expect.equal freshConfig.ConfigFilePath expected_config_file_path "config file path is not correct"
@@ -52,7 +52,7 @@ let ``Toplevel API tests`` =
         ])
 
         testSequenced (testList "updateIndex" [
-            yield! testFixture (Fixtures.withFreshConfigAndCache (get_gh_api_token())) [
+            yield! testFixture (Fixtures.withFreshConfigAndCachePreview (get_gh_api_token())) [
                 "updateIndex returns OK",
                     fun (freshConfig, _) ->
                         Expect.isOk (API.UpdateIndex(freshConfig, ?Token = get_gh_api_token())) "updateIndex did not return OK"

--- a/tests/ARCValidationPackages.Tests/TopLevelAPITests.fs
+++ b/tests/ARCValidationPackages.Tests/TopLevelAPITests.fs
@@ -26,10 +26,16 @@ let ``Toplevel API tests`` =
                     fun (freshConfig, _) ->
                         Expect.equal freshConfig.ConfigFilePath expected_config_file_path "config file path is not correct"
 
-                "Fresh package cache folder",
+                "Fresh package cache preview folder",
                     fun (freshConfig, _) ->
-                        Expect.equal freshConfig.PackageCacheFolder expected_package_cache_folder_path_preview "package cache folder path is not correct"
+                        Expect.equal freshConfig.PackageCacheFolderPreview expected_package_cache_folder_path_preview "package cache preview folder path is not correct"
+                
+                
+                "Fresh package cache release folder",
+                    fun (freshConfig, _) ->
+                        Expect.equal freshConfig.PackageCacheFolderRelease expected_package_cache_folder_path_release "package cache release folder path is not correct"
 
+                
                 "Fresh config package index contains packages",
                     fun (freshConfig, _) ->
                         Expect.isGreaterThan freshConfig.PackageIndex.Length 0 "fresh config package index was empty"

--- a/tests/ARCValidationPackages.Tests/TopLevelAPITests.fs
+++ b/tests/ARCValidationPackages.Tests/TopLevelAPITests.fs
@@ -12,51 +12,51 @@ open AVPRIndex.Domain
 [<Tests>]
 let ``Toplevel API tests`` =
     testSequenced (testList "Toplevel API tests" [
-        testSequenced (testList "Toplevel github API tests" [
-
+        testSequenced (testList "API.Common" [
             test "getSyncedConfigAndCache returns OK" {
                 resetConfigEnvironment()
-                let syncResult = API.GetSyncedConfigAndCache(false, ?Token = get_gh_api_token())
+                let syncResult = API.Common.GetSyncedConfigAndCache(?Token = get_gh_api_token())
                 Expect.isOk (syncResult) "updateIndex did not return OK"
             }
-
             testSequenced (testList "getSyncedConfigAndCache" [
 
-                yield! testFixture (Fixtures.withFreshConfigAndCachePreview (get_gh_api_token())) [
+                yield! testFixture (Fixtures.withFreshConfigAndCaches (get_gh_api_token())) [
                     "Fresh config filepath",
-                        fun (freshConfig, _) ->
+                        fun (freshConfig, _, _) ->
                             Expect.equal freshConfig.ConfigFilePath expected_config_file_path "config file path is not correct"
 
                     "Fresh package cache preview folder",
-                        fun (freshConfig, _) ->
+                        fun (freshConfig, _, _) ->
                             Expect.equal freshConfig.PackageCacheFolderPreview expected_package_cache_folder_path_preview "package cache preview folder path is not correct"
                 
                 
                     "Fresh package cache release folder",
-                        fun (freshConfig, _) ->
+                        fun (freshConfig, _, _) ->
                             Expect.equal freshConfig.PackageCacheFolderRelease expected_package_cache_folder_path_release "package cache release folder path is not correct"
 
                 
                     "Fresh config package index contains packages",
-                        fun (freshConfig, _) ->
+                        fun (freshConfig, _, _) ->
                             Expect.isGreaterThan freshConfig.PackageIndex.Length 0 "fresh config package index was empty"
 
                     "Fresh config package index contains test package",
-                        fun (freshConfig, _) ->
+                        fun (freshConfig, _, _) ->
                             Expect.isTrue (Array.exists (fun (x:ValidationPackageIndex) -> x.Metadata.Name = "test") freshConfig.PackageIndex) "fresh config package index was empty"
                     "Fresh package cache is empty",
 
-                        fun (_, freshCache) ->
+                        fun (_, freshCache, _) ->
                             Expect.equal freshCache.Count 0 "fresh cache was not empty"
                 ]
 
             ])
+        ])
+        testSequenced (testList "API.Preview" [
 
             testSequenced (testList "updateIndex" [
-                yield! testFixture (Fixtures.withFreshConfigAndCachePreview (get_gh_api_token())) [
+                yield! testFixture (Fixtures.withFreshConfigAndCaches (get_gh_api_token())) [
                     "updateIndex returns OK",
-                        fun (freshConfig, _) ->
-                            Expect.isOk (API.UpdateIndex(freshConfig, ?Token = get_gh_api_token())) "updateIndex did not return OK"
+                        fun (freshConfig, _, _) ->
+                            Expect.isOk (API.Preview.UpdateIndex(freshConfig, ?Token = get_gh_api_token())) "updateIndex did not return OK"
                 ]   
             ])
 
@@ -64,43 +64,7 @@ let ``Toplevel API tests`` =
           
             ])
         ])
-        testSequenced (testList "Toplevel AVPR API tests" [
-
-            test "getSyncedConfigAndCache returns OK" {
-                resetConfigEnvironment()
-                let syncResult = API.GetSyncedConfigAndCache(true)
-                Expect.isOk (syncResult) "updateIndex did not return OK"
-            }
-
-            testSequenced (testList "getSyncedConfigAndCache" [
-
-                yield! testFixture (Fixtures.withFreshConfigAndCacheRelease) [
-                    "Fresh config filepath",
-                        fun (freshConfig, _) ->
-                            Expect.equal freshConfig.ConfigFilePath expected_config_file_path "config file path is not correct"
-
-                    "Fresh package cache preview folder",
-                        fun (freshConfig, _) ->
-                            Expect.equal freshConfig.PackageCacheFolderPreview expected_package_cache_folder_path_preview "package cache preview folder path is not correct"
-                
-                    "Fresh package cache release folder",
-                        fun (freshConfig, _) ->
-                            Expect.equal freshConfig.PackageCacheFolderRelease expected_package_cache_folder_path_release "package cache release folder path is not correct"
-                
-                    "Fresh config package index contains packages",
-                        fun (freshConfig, _) ->
-                            Expect.isGreaterThan freshConfig.PackageIndex.Length 0 "fresh config package index was empty"
-
-                    "Fresh config package index contains test package",
-                        fun (freshConfig, _) ->
-                            Expect.isTrue (Array.exists (fun (x:ValidationPackageIndex) -> x.Metadata.Name = "test") freshConfig.PackageIndex) "fresh config package index was empty"
-                    "Fresh package cache is empty",
-
-                        fun (_, freshCache) ->
-                            Expect.equal freshCache.Count 0 "fresh cache was not empty"
-                ]
-
-            ])
+        testSequenced (testList "API.AVPR" [
 
             testSequenced (testList "saveAndCachePackage" [
           

--- a/tests/ARCValidationPackages.Tests/TopLevelAPITests.fs
+++ b/tests/ARCValidationPackages.Tests/TopLevelAPITests.fs
@@ -12,54 +12,98 @@ open AVPRIndex.Domain
 [<Tests>]
 let ``Toplevel API tests`` =
     testSequenced (testList "Toplevel API tests" [
+        testSequenced (testList "Toplevel github API tests" [
 
-        test "getSyncedConfigAndCache returns OK" {
-            resetConfigEnvironment()
-            let syncResult = API.GetSyncedConfigAndCache(false, ?Token = get_gh_api_token())
-            Expect.isOk (syncResult) "updateIndex did not return OK"
-        }
+            test "getSyncedConfigAndCache returns OK" {
+                resetConfigEnvironment()
+                let syncResult = API.GetSyncedConfigAndCache(false, ?Token = get_gh_api_token())
+                Expect.isOk (syncResult) "updateIndex did not return OK"
+            }
 
-        testSequenced (testList "getSyncedConfigAndCache" [
+            testSequenced (testList "getSyncedConfigAndCache" [
 
-            yield! testFixture (Fixtures.withFreshConfigAndCachePreview (get_gh_api_token())) [
-                "Fresh config filepath",
-                    fun (freshConfig, _) ->
-                        Expect.equal freshConfig.ConfigFilePath expected_config_file_path "config file path is not correct"
+                yield! testFixture (Fixtures.withFreshConfigAndCachePreview (get_gh_api_token())) [
+                    "Fresh config filepath",
+                        fun (freshConfig, _) ->
+                            Expect.equal freshConfig.ConfigFilePath expected_config_file_path "config file path is not correct"
 
-                "Fresh package cache preview folder",
-                    fun (freshConfig, _) ->
-                        Expect.equal freshConfig.PackageCacheFolderPreview expected_package_cache_folder_path_preview "package cache preview folder path is not correct"
+                    "Fresh package cache preview folder",
+                        fun (freshConfig, _) ->
+                            Expect.equal freshConfig.PackageCacheFolderPreview expected_package_cache_folder_path_preview "package cache preview folder path is not correct"
                 
                 
-                "Fresh package cache release folder",
-                    fun (freshConfig, _) ->
-                        Expect.equal freshConfig.PackageCacheFolderRelease expected_package_cache_folder_path_release "package cache release folder path is not correct"
+                    "Fresh package cache release folder",
+                        fun (freshConfig, _) ->
+                            Expect.equal freshConfig.PackageCacheFolderRelease expected_package_cache_folder_path_release "package cache release folder path is not correct"
 
                 
-                "Fresh config package index contains packages",
-                    fun (freshConfig, _) ->
-                        Expect.isGreaterThan freshConfig.PackageIndex.Length 0 "fresh config package index was empty"
+                    "Fresh config package index contains packages",
+                        fun (freshConfig, _) ->
+                            Expect.isGreaterThan freshConfig.PackageIndex.Length 0 "fresh config package index was empty"
 
-                "Fresh config package index contains test package",
-                    fun (freshConfig, _) ->
-                        Expect.isTrue (Array.exists (fun (x:ValidationPackageIndex) -> x.Metadata.Name = "test") freshConfig.PackageIndex) "fresh config package index was empty"
-                "Fresh package cache is empty",
+                    "Fresh config package index contains test package",
+                        fun (freshConfig, _) ->
+                            Expect.isTrue (Array.exists (fun (x:ValidationPackageIndex) -> x.Metadata.Name = "test") freshConfig.PackageIndex) "fresh config package index was empty"
+                    "Fresh package cache is empty",
 
-                    fun (_, freshCache) ->
-                        Expect.equal freshCache.Count 0 "fresh cache was not empty"
-            ]
+                        fun (_, freshCache) ->
+                            Expect.equal freshCache.Count 0 "fresh cache was not empty"
+                ]
 
-        ])
+            ])
 
-        testSequenced (testList "updateIndex" [
-            yield! testFixture (Fixtures.withFreshConfigAndCachePreview (get_gh_api_token())) [
-                "updateIndex returns OK",
-                    fun (freshConfig, _) ->
-                        Expect.isOk (API.UpdateIndex(freshConfig, ?Token = get_gh_api_token())) "updateIndex did not return OK"
-            ]   
-        ])
+            testSequenced (testList "updateIndex" [
+                yield! testFixture (Fixtures.withFreshConfigAndCachePreview (get_gh_api_token())) [
+                    "updateIndex returns OK",
+                        fun (freshConfig, _) ->
+                            Expect.isOk (API.UpdateIndex(freshConfig, ?Token = get_gh_api_token())) "updateIndex did not return OK"
+                ]   
+            ])
 
-        testSequenced (testList "saveAndCachePackage" [
+            testSequenced (testList "saveAndCachePackage" [
           
+            ])
+        ])
+        testSequenced (testList "Toplevel AVPR API tests" [
+
+            test "getSyncedConfigAndCache returns OK" {
+                resetConfigEnvironment()
+                let syncResult = API.GetSyncedConfigAndCache(true)
+                Expect.isOk (syncResult) "updateIndex did not return OK"
+            }
+
+            testSequenced (testList "getSyncedConfigAndCache" [
+
+                yield! testFixture (Fixtures.withFreshConfigAndCachePreview (get_gh_api_token())) [
+                    "Fresh config filepath",
+                        fun (freshConfig, _) ->
+                            Expect.equal freshConfig.ConfigFilePath expected_config_file_path "config file path is not correct"
+
+                    "Fresh package cache preview folder",
+                        fun (freshConfig, _) ->
+                            Expect.equal freshConfig.PackageCacheFolderPreview expected_package_cache_folder_path_preview "package cache preview folder path is not correct"
+                
+                    "Fresh package cache release folder",
+                        fun (freshConfig, _) ->
+                            Expect.equal freshConfig.PackageCacheFolderRelease expected_package_cache_folder_path_release "package cache release folder path is not correct"
+                
+                    "Fresh config package index contains packages",
+                        fun (freshConfig, _) ->
+                            Expect.isGreaterThan freshConfig.PackageIndex.Length 0 "fresh config package index was empty"
+
+                    "Fresh config package index contains test package",
+                        fun (freshConfig, _) ->
+                            Expect.isTrue (Array.exists (fun (x:ValidationPackageIndex) -> x.Metadata.Name = "test") freshConfig.PackageIndex) "fresh config package index was empty"
+                    "Fresh package cache is empty",
+
+                        fun (_, freshCache) ->
+                            Expect.equal freshCache.Count 0 "fresh cache was not empty"
+                ]
+
+            ])
+
+            testSequenced (testList "saveAndCachePackage" [
+          
+            ])
         ])
     ])

--- a/tests/ARCValidationPackages.Tests/TopLevelAPITests.fs
+++ b/tests/ARCValidationPackages.Tests/TopLevelAPITests.fs
@@ -12,13 +12,13 @@ open AVPRIndex.Domain
 [<Tests>]
 let ``Toplevel API tests`` =
     testSequenced (testList "Toplevel API tests" [
-        testSequenced (testList "API.Common" [
-            test "getSyncedConfigAndCache returns OK" {
+        testSequenced (testList "Common API" [
+            test "GetSyncedConfigAndCache returns OK" {
                 resetConfigEnvironment()
                 let syncResult = API.Common.GetSyncedConfigAndCache(?Token = get_gh_api_token())
-                Expect.isOk (syncResult) "updateIndex did not return OK"
+                Expect.isOk (syncResult) "GetSyncedConfigAndCache did not return OK"
             }
-            testSequenced (testList "getSyncedConfigAndCache" [
+            testSequenced (testList "GetSyncedConfigAndCache" [
 
                 yield! testFixture (Fixtures.withFreshConfigAndCaches (get_gh_api_token())) [
                     "Fresh config filepath",
@@ -29,12 +29,10 @@ let ``Toplevel API tests`` =
                         fun (freshConfig, _, _) ->
                             Expect.equal freshConfig.PackageCacheFolderPreview expected_package_cache_folder_path_preview "package cache preview folder path is not correct"
                 
-                
                     "Fresh package cache release folder",
                         fun (freshConfig, _, _) ->
                             Expect.equal freshConfig.PackageCacheFolderRelease expected_package_cache_folder_path_release "package cache release folder path is not correct"
 
-                
                     "Fresh config package index contains packages",
                         fun (freshConfig, _, _) ->
                             Expect.isGreaterThan freshConfig.PackageIndex.Length 0 "fresh config package index was empty"
@@ -42,6 +40,7 @@ let ``Toplevel API tests`` =
                     "Fresh config package index contains test package",
                         fun (freshConfig, _, _) ->
                             Expect.isTrue (Array.exists (fun (x:ValidationPackageIndex) -> x.Metadata.Name = "test") freshConfig.PackageIndex) "fresh config package index was empty"
+                    
                     "Fresh package cache is empty",
 
                         fun (_, freshCache, _) ->
@@ -49,25 +48,170 @@ let ``Toplevel API tests`` =
                 ]
 
             ])
-        ])
-        testSequenced (testList "API.Preview" [
+            testSequenced (testList "ListCachedPackages" [
 
-            testSequenced (testList "updateIndex" [
+            ])
+        ])
+        testSequenced (testList "Preview API" [
+
+            testSequenced (testList "UpdateIndex" [
                 yield! testFixture (Fixtures.withFreshConfigAndCaches (get_gh_api_token())) [
-                    "updateIndex returns OK",
+                    "UpdateIndex returns OK",
                         fun (freshConfig, _, _) ->
-                            Expect.isOk (API.Preview.UpdateIndex(freshConfig, ?Token = get_gh_api_token())) "updateIndex did not return OK"
-                ]   
+                            Expect.isOk (API.Preview.UpdateIndex(freshConfig, ?Token = get_gh_api_token())) "UpdateIndex did not return OK"
+                ]
             ])
+            testSequenced (testList "ListIndexedPackages" [
 
-            testSequenced (testList "saveAndCachePackage" [
-          
+                // here, wee need persistent config and caches across the tests instead of a fixture for each test case
+                resetConfigEnvironment()
+                let config, _, _ = Result.okValue (API.Common.GetSyncedConfigAndCache(?Token = get_gh_api_token()))
+                
+                // we need a package index to be able to list indexed packages
+                test "UpdateIndex returns OK" {
+                    Expect.isOk (API.Preview.UpdateIndex(config, ?Token = get_gh_api_token())) "UpdateIndex did not return OK"
+                }
+                test "ListIndexedPackages returns OK" {
+                    Expect.isOk (API.Preview.ListIndexedPackages(config)) "ListIndexedPackages did not return OK"
+                }
+
+            ])
+            testSequenced (testList "SaveAndCachePackage" [
+                
+                // here, wee need persistent config and caches across the tests instead of a fixture for each test case
+                resetConfigEnvironment()
+                let config, _, previewCache = Result.okValue (API.Common.GetSyncedConfigAndCache(?Token = get_gh_api_token()))
+                let firstIndexedPackage = config.PackageIndex.[0]
+                let firstPackageName = firstIndexedPackage.Metadata.Name
+                let firstPackageVersion = ValidationPackageMetadata.getSemanticVersionString firstIndexedPackage.Metadata
+
+                test "SaveAndCachePackage returns OK" {
+                    Expect.isOk (API.Preview.SaveAndCachePackage(previewCache, firstIndexedPackage)) "SaveAndCachePackage did not return OK"
+                }
+                test "package is cached after running SaveAndCachePackage" {
+                    previewCache 
+                    |> Expect.packageCacheContainsPackage firstPackageName firstPackageVersion
+                }
+                test "package exists after running SaveAndCachePackage" {
+                    Expect.isTrue (File.Exists (Path.Combine(expected_package_cache_folder_path_preview, $"{firstPackageName}@{firstPackageVersion}.fsx"))) $"{firstPackageName}@{firstPackageVersion}.fsx did not exist at {expected_package_cache_folder_path_preview}"
+                }
+            ])
+            testSequenced (testList "InstallPackage" [
+                
+                // here, wee need persistent config and caches across the tests instead of a fixture for each test case
+                resetConfigEnvironment()
+                let config, _, previewCache = Result.okValue (API.Common.GetSyncedConfigAndCache(?Token = get_gh_api_token()))
+                let firstIndexedPackage = config.PackageIndex.[0]
+                let firstPackageName = firstIndexedPackage.Metadata.Name
+                let firstPackageVersion = ValidationPackageMetadata.getSemanticVersionString firstIndexedPackage.Metadata
+
+                test "InstallPackage returns OK" {
+                    Expect.isOk (API.Preview.InstallPackage(config, previewCache, firstPackageName, SemVer = firstPackageVersion)) "InstallPackage did not return OK"
+                }
+                test "package is cached after running InstallPackage" {
+                    previewCache 
+                    |> Expect.packageCacheContainsPackage firstPackageName firstPackageVersion
+                }
+                test "package exists after running InstallPackage" {
+                    Expect.isTrue (File.Exists (Path.Combine(expected_package_cache_folder_path_preview, $"{firstPackageName}@{firstPackageVersion}.fsx"))) $"{firstPackageName}@{firstPackageVersion}.fsx did not exist at {expected_package_cache_folder_path_preview}"
+                }
+            ])
+            testSequenced (testList "UninstallPackage" [
+                // here, wee need persistent config and caches across the tests instead of a fixture for each test case
+                resetConfigEnvironment()
+                let config, _, previewCache = Result.okValue (API.Common.GetSyncedConfigAndCache(?Token = get_gh_api_token()))
+                let firstIndexedPackage = config.PackageIndex.[0]
+                let firstPackageName = firstIndexedPackage.Metadata.Name
+                let firstPackageVersion = ValidationPackageMetadata.getSemanticVersionString firstIndexedPackage.Metadata
+
+                test "InstallPackage returns OK" {
+                    Expect.isOk (API.Preview.InstallPackage(config, previewCache, firstPackageName, SemVer = firstPackageVersion)) "InstallPackage did not return OK"
+                }
+                test "package is cached after running InstallPackage" {
+                    previewCache 
+                    |> Expect.packageCacheContainsPackage firstPackageName firstPackageVersion
+                }
+                test "package exists after running InstallPackage" {
+                    Expect.isTrue (File.Exists (Path.Combine(expected_package_cache_folder_path_preview, $"{firstPackageName}@{firstPackageVersion}.fsx"))) $"{firstPackageName}@{firstPackageVersion}.fsx did not exist at {expected_package_cache_folder_path_preview}"
+                }
+                test "UninstallPackage with version flag returns OK" {
+                    Expect.isOk (API.Preview.UninstallPackage(previewCache, firstPackageName, SemVer = firstPackageVersion)) "UninstallPackage did not return OK"
+                }
+                test "package version is not cached anymore after running UninstallPackage" {
+                    Expect.isFalse (previewCache[firstPackageName].ContainsKey(firstPackageVersion)) "version was not removed from the cache"
+                }
+                test "package does not exist anymore after running UninstallPackage" {
+                    Expect.isFalse (File.Exists (Path.Combine(expected_package_cache_folder_path_preview, $"{firstPackageName}@{firstPackageVersion}.fsx"))) $"{firstPackageName}@{firstPackageVersion}.fsx did not exist at {expected_package_cache_folder_path_preview}"
+                }
             ])
         ])
-        testSequenced (testList "API.AVPR" [
+        testSequenced (testList "AVPR API" [
 
-            testSequenced (testList "saveAndCachePackage" [
-          
+            testSequenced (testList "SaveAndCachePackage" [
+                // here, wee need persistent config and caches across the tests instead of a fixture for each test case
+                resetConfigEnvironment()
+                let config, avprCache, _ = Result.okValue (API.Common.GetSyncedConfigAndCache(?Token = get_gh_api_token()))
+                let firstIndexedPackage = config.PackageIndex.[0]
+                let firstPackageName = firstIndexedPackage.Metadata.Name
+                let firstPackageVersion = ValidationPackageMetadata.getSemanticVersionString firstIndexedPackage.Metadata
+
+                test "SaveAndCachePackage returns OK" {
+                    Expect.isOk (API.AVPR.SaveAndCachePackage(avprCache, firstPackageName, packageVersion = firstPackageVersion )) "SaveAndCachePackage did not return OK"
+                }
+                test "package is cached after running SaveAndCachePackage" {
+                    avprCache 
+                    |> Expect.packageCacheContainsPackage firstPackageName firstPackageVersion
+                }
+                test "package exists after running SaveAndCachePackage" {
+                    Expect.isTrue (File.Exists (Path.Combine(expected_package_cache_folder_path_release, $"{firstPackageName}@{firstPackageVersion}.fsx"))) $"{firstPackageName}@{firstPackageVersion}.fsx did not exist at {expected_package_cache_folder_path_release}"
+                }
+            ])
+            testSequenced (testList "InstallPackage" [
+                // here, wee need persistent config and caches across the tests instead of a fixture for each test case
+                resetConfigEnvironment()
+                let config, avprCache, _ = Result.okValue (API.Common.GetSyncedConfigAndCache(?Token = get_gh_api_token()))
+                let firstIndexedPackage = config.PackageIndex.[0]
+                let firstPackageName = firstIndexedPackage.Metadata.Name
+                let firstPackageVersion = ValidationPackageMetadata.getSemanticVersionString firstIndexedPackage.Metadata
+
+                test "InstallPackage returns OK" {
+                    Expect.isOk (API.AVPR.InstallPackage(avprCache, firstPackageName, SemVer = firstPackageVersion)) "InstallPackage did not return OK"
+                }
+                test "package is cached after running InstallPackage" {
+                    avprCache 
+                    |> Expect.packageCacheContainsPackage firstPackageName firstPackageVersion
+                }
+                test "package exists after running InstallPackage" {
+                    Expect.isTrue (File.Exists (Path.Combine(expected_package_cache_folder_path_release, $"{firstPackageName}@{firstPackageVersion}.fsx"))) $"{firstPackageName}@{firstPackageVersion}.fsx did not exist at {expected_package_cache_folder_path_release}"
+                }
+            ])
+            testSequenced (testList "UnInstallPackage" [
+                // here, wee need persistent config and caches across the tests instead of a fixture for each test case
+                resetConfigEnvironment()
+                let config, avprCache, _ = Result.okValue (API.Common.GetSyncedConfigAndCache(?Token = get_gh_api_token()))
+                let firstIndexedPackage = config.PackageIndex.[0]
+                let firstPackageName = firstIndexedPackage.Metadata.Name
+                let firstPackageVersion = ValidationPackageMetadata.getSemanticVersionString firstIndexedPackage.Metadata
+
+                test "InstallPackage returns OK" {
+                    Expect.isOk (API.Preview.InstallPackage(config, avprCache, firstPackageName, SemVer = firstPackageVersion)) "InstallPackage did not return OK"
+                }
+                test "package is cached after running InstallPackage" {
+                    avprCache 
+                    |> Expect.packageCacheContainsPackage firstPackageName firstPackageVersion
+                }
+                test "package exists after running InstallPackage" {
+                    Expect.isTrue (File.Exists (Path.Combine(expected_package_cache_folder_path_release, $"{firstPackageName}@{firstPackageVersion}.fsx"))) $"{firstPackageName}@{firstPackageVersion}.fsx did not exist at {expected_package_cache_folder_path_release}"
+                }
+                test "UninstallPackage with version flag returns OK" {
+                    Expect.isOk (API.Preview.UninstallPackage(avprCache, firstPackageName, SemVer = firstPackageVersion)) "UninstallPackage did not return OK"
+                }
+                test "package version is not cached anymore after running UninstallPackage" {
+                    Expect.isFalse (avprCache[firstPackageName].ContainsKey(firstPackageVersion)) "version was not removed from the cache"
+                }
+                test "package does not exist anymore after running UninstallPackage" {
+                    Expect.isFalse (File.Exists (Path.Combine(expected_package_cache_folder_path_preview, $"{firstPackageName}@{firstPackageVersion}.fsx"))) $"{firstPackageName}@{firstPackageVersion}.fsx did not exist at {expected_package_cache_folder_path_release}"
+                }
             ])
         ])
     ])

--- a/tests/ARCValidationPackages.Tests/TopLevelAPITests.fs
+++ b/tests/ARCValidationPackages.Tests/TopLevelAPITests.fs
@@ -74,7 +74,7 @@ let ``Toplevel API tests`` =
 
             testSequenced (testList "getSyncedConfigAndCache" [
 
-                yield! testFixture (Fixtures.withFreshConfigAndCachePreview (get_gh_api_token())) [
+                yield! testFixture (Fixtures.withFreshConfigAndCacheRelease) [
                     "Fresh config filepath",
                         fun (freshConfig, _) ->
                             Expect.equal freshConfig.ConfigFilePath expected_config_file_path "config file path is not correct"

--- a/tests/ARCValidationPackages.Tests/TopLevelAPITests.fs
+++ b/tests/ARCValidationPackages.Tests/TopLevelAPITests.fs
@@ -15,7 +15,7 @@ let ``Toplevel API tests`` =
 
         test "getSyncedConfigAndCache returns OK" {
             resetConfigEnvironment()
-            let syncResult = API.GetSyncedConfigAndCache(?Token = get_gh_api_token())
+            let syncResult = API.GetSyncedConfigAndCache(false, ?Token = get_gh_api_token())
             Expect.isOk (syncResult) "updateIndex did not return OK"
         }
 

--- a/tests/Common/TestUtils.fs
+++ b/tests/Common/TestUtils.fs
@@ -37,12 +37,15 @@ module TestUtils =
         // remove any existing config folder for running tests
         if Directory.Exists(expected_config_folder_path) then Directory.Delete(expected_config_folder_path, true)
         if Directory.Exists(expected_package_cache_folder_path_preview) then Directory.Delete(expected_package_cache_folder_path_preview, true)
+        if Directory.Exists(expected_package_cache_folder_path_release) then Directory.Delete(expected_package_cache_folder_path_release, true)
         // ensure that these file do not exist before running tests
         if File.Exists(expected_config_file_path) then File.Delete(expected_config_file_path)
         if File.Exists(expected_package_cache_file_path_preview) then File.Delete(expected_package_cache_file_path_preview)
+        if File.Exists(expected_package_cache_file_path_release) then File.Delete(expected_package_cache_file_path_release)
 
     let deleteDefaultPackageCache() =
         if File.Exists(expected_package_cache_file_path_preview) then File.Delete(expected_package_cache_file_path_preview)
+        if File.Exists(expected_package_cache_file_path_release) then File.Delete(expected_package_cache_file_path_release)
 
     let deleteDefaultConfig() =
         if File.Exists(expected_config_file_path) then File.Delete(expected_config_file_path)

--- a/tests/FSharpConsole/Program.fs
+++ b/tests/FSharpConsole/Program.fs
@@ -10,6 +10,6 @@ let token =
 let configPath = @"C:/Users/schne/Desktop/lol/test.json"
 let cacheFolder = @"C:/Users/schne/Desktop/lol/cache"
 
-let syncResult = API.GetSyncedConfigAndCache(ConfigPath = configPath, CacheFolder = cacheFolder, ?Token = token)
+let syncResult = API.GetSyncedConfigAndCache(false, ConfigPath = configPath, CacheFolderPreview = cacheFolder, ?Token = token)
 
 printfn "%A" syncResult

--- a/tests/FSharpConsole/Program.fs
+++ b/tests/FSharpConsole/Program.fs
@@ -10,6 +10,6 @@ let token =
 let configPath = @"C:/Users/schne/Desktop/lol/test.json"
 let cacheFolder = @"C:/Users/schne/Desktop/lol/cache"
 
-let syncResult = API.GetSyncedConfigAndCache(false, ConfigPath = configPath, CacheFolderPreview = cacheFolder, ?Token = token)
+let syncResult = API.Common.GetSyncedConfigAndCache(ConfigPath = configPath, CacheFolderPreview = cacheFolder, ?Token = token)
 
 printfn "%A" syncResult

--- a/tests/arc-validate.Tests/CLITests/PackageCommandTests.fs
+++ b/tests/arc-validate.Tests/CLITests/PackageCommandTests.fs
@@ -18,13 +18,13 @@ open JUnit
 [<Tests>]
 let ``PackageCommand CLI Tests`` =
     testSequenced (testList "arc-validate package" [
-        testSequenced (testList "arc-validate preview package" [
+        testSequenced (testList "preview" [
             testSequenced (testList "list" [
                 yield! 
                     testFixture (Fixtures.withToolExecution 
                         true
                         "../../../../../publish/arc-validate" 
-                        [|"-v"; "package"; "list";|]
+                        [|"--verbose"; "package"; "list";|]
                         (get_gh_api_token())
                     ) [
                         "Exit code is 0 (before install)" , 
@@ -39,7 +39,7 @@ let ``PackageCommand CLI Tests`` =
                     testFixture (Fixtures.withToolExecution 
                         true
                         "../../../../../publish/arc-validate" 
-                        [|"-v"; "package"; "install"; "test"; "-pv"; "1.0.0"; "-pr"|]
+                        [|"--verbose"; "package"; "install"; "test"; "-v"; "1.0.0"; "--preview"|]
                         (get_gh_api_token())
                     ) [
                         "Exit code is 0" , 
@@ -63,7 +63,7 @@ let ``PackageCommand CLI Tests`` =
                     testFixture (Fixtures.withToolExecution 
                         false
                         "../../../../../publish/arc-validate" 
-                        [|"-v"; "package"; "list";|]
+                        [|"--verbose"; "package"; "list";|]
                         (get_gh_api_token())
                     ) [
                         "Exit code is 0 (after install)" , 
@@ -77,7 +77,7 @@ let ``PackageCommand CLI Tests`` =
                     testFixture (Fixtures.withToolExecution 
                         false
                         "../../../../../publish/arc-validate" 
-                        [|"-v"; "package"; "uninstall"; "test"; "-pr"|]
+                        [|"--verbose"; "package"; "uninstall"; "test"; "--preview"|]
                         (get_gh_api_token())
                     ) [
                         "Exit code is 0" , 
@@ -95,7 +95,7 @@ let ``PackageCommand CLI Tests`` =
                     testFixture (Fixtures.withToolExecution 
                         false
                         "../../../../../publish/arc-validate" 
-                        [|"-v"; "package"; "list";|]
+                        [|"--verbose"; "package"; "list";|]
                         (get_gh_api_token())
                     ) [
                         "Exit code is 0 (after uninstall)" , 
@@ -109,7 +109,7 @@ let ``PackageCommand CLI Tests`` =
                     testFixture (Fixtures.withToolExecution 
                         true
                         "../../../../../publish/arc-validate" 
-                        [|"-v"; "package"; "install"; "test"; "-pv"; "2.0.0"; "-pr"|]
+                        [|"--verbose"; "package"; "install"; "test"; "-v"; "2.0.0"; "--preview"|]
                         (get_gh_api_token())
                     ) [
                         "Exit code is 0" , 
@@ -133,7 +133,7 @@ let ``PackageCommand CLI Tests`` =
                     testFixture (Fixtures.withToolExecution 
                         false
                         "../../../../../publish/arc-validate" 
-                        [|"-v"; "package"; "list";|]
+                        [|"--verbose"; "package"; "list";|]
                         (get_gh_api_token())
                     ) [
                         "Exit code is 0 (after install)" , 
@@ -147,7 +147,7 @@ let ``PackageCommand CLI Tests`` =
                     testFixture (Fixtures.withToolExecution 
                         false
                         "../../../../../publish/arc-validate" 
-                        [|"-v"; "package"; "uninstall"; "test"; "-pr"|]
+                        [|"--verbose"; "package"; "uninstall"; "test"; "--preview"|]
                         (get_gh_api_token())
                     ) [
                         "Exit code is 0" , 
@@ -165,7 +165,7 @@ let ``PackageCommand CLI Tests`` =
                     testFixture (Fixtures.withToolExecution 
                         false
                         "../../../../../publish/arc-validate" 
-                        [|"-v"; "package"; "list";|]
+                        [|"--verbose"; "package"; "list";|]
                         (get_gh_api_token())
                     ) [
                         "Exit code is 0 (after uninstall)" , 
@@ -179,7 +179,7 @@ let ``PackageCommand CLI Tests`` =
                     testFixture (Fixtures.withToolExecution 
                         false
                         "../../../../../publish/arc-validate" 
-                        [|"-v"; "package"; "update-index"|]
+                        [|"--verbose"; "package"; "update-index"|]
                         (get_gh_api_token())
                     ) [
                         "Exit code is 0" , 
@@ -187,14 +187,29 @@ let ``PackageCommand CLI Tests`` =
                     ]
             ])
         ])
-        testSequenced (testList "arc-validate release package" [
-            testSequenced (testList "install test v3" [
+        testSequenced (testList "avpr" [
+            testSequenced (testList "list" [
                 yield! 
                     testFixture (Fixtures.withToolExecution 
                         true
                         "../../../../../publish/arc-validate" 
-                        [|"-v"; "package"; "install"; "test"; "-pv"; "3.0.0"|]
-                        None
+                        [|"--verbose"; "package"; "list";|]
+                        (get_gh_api_token())
+                    ) [
+                        "Exit code is 0 (before install)" , 
+                            fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args)
+                        "test package is not listed (before install)" , 
+                            fun tool args proc -> Expect.isFalse (proc.Result.Output.Contains("test")) (ErrorMessage.withProcessDiagnostics $"Console output {proc.Result.Output} did contain the package" proc tool args)
+                
+                    ]
+            ])
+            testSequenced (testList "install test v1" [
+                yield! 
+                    testFixture (Fixtures.withToolExecution 
+                        true
+                        "../../../../../publish/arc-validate" 
+                        [|"--verbose"; "package"; "install"; "test"; "-v"; "1.0.0"|]
+                        (get_gh_api_token())
                     ) [
                         "Exit code is 0" , 
                             fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args)
@@ -203,23 +218,36 @@ let ``PackageCommand CLI Tests`` =
                         "Cache exists" ,  
                             fun tool args proc -> Expect.isTrue (File.Exists(expected_package_cache_file_path_release)) (ErrorMessage.withCLIDiagnostics $"package cache was not created at {expected_package_cache_file_path_release}." tool args)
                         "Package script exists" ,  
-                            fun tool args proc -> Expect.isTrue (File.Exists(Path.Combine(expected_package_cache_folder_path_release, "test.fsx"))) (ErrorMessage.withCLIDiagnostics $"package file was not installed at expected location." tool args)
+                            fun tool args proc -> Expect.isTrue (File.Exists(Path.Combine(expected_package_cache_folder_path_release, "test@1.0.0.fsx"))) (ErrorMessage.withCLIDiagnostics $"package file was not installed at expected location." tool args)
                         "Package script has correct content" ,
                             fun tool args proc -> 
                                 Expect.equal 
-                                    (File.ReadAllText(Path.Combine(expected_package_cache_folder_path_release, "test.fsx")).ReplaceLineEndings())
-                                    test_package_script_content_v3
+                                    (File.ReadAllText(Path.Combine(expected_package_cache_folder_path_release, "test@1.0.0.fsx")).ReplaceLineEndings())
+                                    test_package_script_content_v1
                                     (ErrorMessage.withCLIDiagnostics $"Package script did not have correct content" tool args)
                     ]
             ])
-            
-            testSequenced (testList "uninstall test v3" [
+            testSequenced (testList "list v1" [
                 yield! 
                     testFixture (Fixtures.withToolExecution 
                         false
                         "../../../../../publish/arc-validate" 
-                        [|"-v"; "package"; "uninstall"; "test"|]
-                        None
+                        [|"--verbose"; "package"; "list";|]
+                        (get_gh_api_token())
+                    ) [
+                        "Exit code is 0 (after install)" , 
+                            fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args)
+                        "test package is listed (after install)" , 
+                            fun tool args proc -> Expect.isTrue (proc.Result.Output.Contains("test @ version 1.0.0")) (ErrorMessage.withProcessDiagnostics $"Console output {proc.Result.Output} did not contain the package" proc tool args)
+                    ]
+            ])
+            testSequenced (testList "uninstall test v1" [
+                yield! 
+                    testFixture (Fixtures.withToolExecution 
+                        false
+                        "../../../../../publish/arc-validate" 
+                        [|"--verbose"; "package"; "uninstall"; "test"|]
+                        (get_gh_api_token())
                     ) [
                         "Exit code is 0" , 
                             fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args)
@@ -228,7 +256,91 @@ let ``PackageCommand CLI Tests`` =
                         "Cache still exists" ,  
                             fun tool args proc -> Expect.isTrue (File.Exists(expected_package_cache_file_path_release)) (ErrorMessage.withCLIDiagnostics $"package cache was not created at {expected_package_cache_file_path_release}." tool args)
                         "test package script does not exist anymore" ,  
-                            fun tool args proc -> Expect.isFalse (File.Exists(Path.Combine(expected_package_cache_folder_path_release, "test.fsx"))) (ErrorMessage.withCLIDiagnostics $"package file was not uninstalled at expected location." tool args)
+                            fun tool args proc -> Expect.isFalse (File.Exists(Path.Combine(expected_package_cache_folder_path_release, "test@1.0.0.fsx"))) (ErrorMessage.withCLIDiagnostics $"package file was not uninstalled at expected location." tool args)
+                    ]
+            ])
+            testSequenced (testList "list v1" [
+                yield! 
+                    testFixture (Fixtures.withToolExecution 
+                        false
+                        "../../../../../publish/arc-validate" 
+                        [|"--verbose"; "package"; "list";|]
+                        (get_gh_api_token())
+                    ) [
+                        "Exit code is 0 (after uninstall)" , 
+                            fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args)
+                        "test package is not listed (after uninstall)" , 
+                            fun tool args proc -> Expect.isFalse (proc.Result.Output.Contains("test @ version 1.0.0")) (ErrorMessage.withProcessDiagnostics $"Console output {proc.Result.Output} did contain the package" proc tool args)
+                    ]
+            ])
+            testSequenced (testList "install test v2" [
+                yield! 
+                    testFixture (Fixtures.withToolExecution 
+                        true
+                        "../../../../../publish/arc-validate" 
+                        [|"--verbose"; "package"; "install"; "test"; "-v"; "2.0.0"|]
+                        (get_gh_api_token())
+                    ) [
+                        "Exit code is 0" , 
+                            fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args)
+                        "Cache folder exists" ,  
+                            fun tool args proc -> Expect.isTrue (Directory.Exists(expected_package_cache_folder_path_release)) (ErrorMessage.withCLIDiagnostics $"package cache folder was not created at {expected_package_cache_folder_path_release}." tool args)
+                        "Cache exists" ,  
+                            fun tool args proc -> Expect.isTrue (File.Exists(expected_package_cache_file_path_release)) (ErrorMessage.withCLIDiagnostics $"package cache was not created at {expected_package_cache_file_path_release}." tool args)
+                        "Package script exists" ,  
+                            fun tool args proc -> Expect.isTrue (File.Exists(Path.Combine(expected_package_cache_folder_path_release, "test@2.0.0.fsx"))) (ErrorMessage.withCLIDiagnostics $"package file was not installed at expected location." tool args)
+                        "Package script has correct content" ,
+                            fun tool args proc -> 
+                                Expect.equal 
+                                    (File.ReadAllText(Path.Combine(expected_package_cache_folder_path_release, "test@2.0.0.fsx")).ReplaceLineEndings())
+                                    test_package_script_content_v2
+                                    (ErrorMessage.withCLIDiagnostics $"Package script did not have correct content" tool args)
+                    ]
+            ])
+            testSequenced (testList "list v2" [
+                yield! 
+                    testFixture (Fixtures.withToolExecution 
+                        false
+                        "../../../../../publish/arc-validate" 
+                        [|"--verbose"; "package"; "list";|]
+                        (get_gh_api_token())
+                    ) [
+                        "Exit code is 0 (after install)" , 
+                            fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args)
+                        "test package is listed (after install)" , 
+                            fun tool args proc -> Expect.isTrue (proc.Result.Output.Contains("test @ version 2.0.0")) (ErrorMessage.withProcessDiagnostics $"Console output {proc.Result.Output} did not contain the package" proc tool args)
+                    ]
+            ])
+            testSequenced (testList "uninstall test v2" [
+                yield! 
+                    testFixture (Fixtures.withToolExecution 
+                        false
+                        "../../../../../publish/arc-validate" 
+                        [|"--verbose"; "package"; "uninstall"; "test";|]
+                        (get_gh_api_token())
+                    ) [
+                        "Exit code is 0" , 
+                            fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args)
+                        "Cache folder still exists" ,  
+                            fun tool args proc -> Expect.isTrue (Directory.Exists(expected_package_cache_folder_path_release)) (ErrorMessage.withCLIDiagnostics $"package cache folder was not created at {expected_package_cache_folder_path_release}." tool args)
+                        "Cache still exists" ,  
+                            fun tool args proc -> Expect.isTrue (File.Exists(expected_package_cache_file_path_release)) (ErrorMessage.withCLIDiagnostics $"package cache was not created at {expected_package_cache_file_path_release}." tool args)
+                        "test package script does not exist anymore" ,  
+                            fun tool args proc -> Expect.isFalse (File.Exists(Path.Combine(expected_package_cache_folder_path_release, "test@2.0.0.fsx"))) (ErrorMessage.withCLIDiagnostics $"package file was not uninstalled at expected location." tool args)
+                    ]
+            ])
+            testSequenced (testList "list v2" [
+                yield! 
+                    testFixture (Fixtures.withToolExecution 
+                        false
+                        "../../../../../publish/arc-validate" 
+                        [|"--verbose"; "package"; "list";|]
+                        (get_gh_api_token())
+                    ) [
+                        "Exit code is 0 (after uninstall)" , 
+                            fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args)
+                        "test package is not listed (after uninstall)" , 
+                            fun tool args proc -> Expect.isFalse (proc.Result.Output.Contains("test @ version 2.0.0")) (ErrorMessage.withProcessDiagnostics $"Console output {proc.Result.Output} did contain the package" proc tool args)
                     ]
             ])
         ])

--- a/tests/arc-validate.Tests/CLITests/PackageCommandTests.fs
+++ b/tests/arc-validate.Tests/CLITests/PackageCommandTests.fs
@@ -38,7 +38,7 @@ let ``PackageCommand CLI Tests`` =
                 testFixture (Fixtures.withToolExecution 
                     true
                     "../../../../../publish/arc-validate" 
-                    [|"-v"; "package"; "install"; "test"; "-pv"; "1.0.0"|]
+                    [|"-v"; "package"; "install"; "test"; "-pv"; "1.0.0"; "-pr"|]
                     (get_gh_api_token())
                 ) [
                     "Exit code is 0" , 
@@ -76,7 +76,7 @@ let ``PackageCommand CLI Tests`` =
                 testFixture (Fixtures.withToolExecution 
                     false
                     "../../../../../publish/arc-validate" 
-                    [|"-v"; "package"; "uninstall"; "test"|]
+                    [|"-v"; "package"; "uninstall"; "test"; "-pr"|]
                     (get_gh_api_token())
                 ) [
                     "Exit code is 0" , 
@@ -108,7 +108,7 @@ let ``PackageCommand CLI Tests`` =
                 testFixture (Fixtures.withToolExecution 
                     true
                     "../../../../../publish/arc-validate" 
-                    [|"-v"; "package"; "install"; "test"; "-pv"; "2.0.0"|]
+                    [|"-v"; "package"; "install"; "test"; "-pv"; "2.0.0"; "-pr"|]
                     (get_gh_api_token())
                 ) [
                     "Exit code is 0" , 
@@ -146,7 +146,7 @@ let ``PackageCommand CLI Tests`` =
                 testFixture (Fixtures.withToolExecution 
                     false
                     "../../../../../publish/arc-validate" 
-                    [|"-v"; "package"; "uninstall"; "test"|]
+                    [|"-v"; "package"; "uninstall"; "test"; "-pr"|]
                     (get_gh_api_token())
                 ) [
                     "Exit code is 0" , 

--- a/tests/arc-validate.Tests/CLITests/PackageCommandTests.fs
+++ b/tests/arc-validate.Tests/CLITests/PackageCommandTests.fs
@@ -18,171 +18,218 @@ open JUnit
 [<Tests>]
 let ``PackageCommand CLI Tests`` =
     testSequenced (testList "arc-validate package" [
-        testSequenced (testList "list" [
-            yield! 
-                testFixture (Fixtures.withToolExecution 
-                    true
-                    "../../../../../publish/arc-validate" 
-                    [|"-v"; "package"; "list";|]
-                    (get_gh_api_token())
-                ) [
-                    "Exit code is 0 (before install)" , 
-                        fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args)
-                    "test package is not listed (before install)" , 
-                        fun tool args proc -> Expect.isFalse (proc.Result.Output.Contains("test")) (ErrorMessage.withProcessDiagnostics $"Console output {proc.Result.Output} did contain the package" proc tool args)
+        testSequenced (testList "arc-validate preview package" [
+            testSequenced (testList "list" [
+                yield! 
+                    testFixture (Fixtures.withToolExecution 
+                        true
+                        "../../../../../publish/arc-validate" 
+                        [|"-v"; "package"; "list";|]
+                        (get_gh_api_token())
+                    ) [
+                        "Exit code is 0 (before install)" , 
+                            fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args)
+                        "test package is not listed (before install)" , 
+                            fun tool args proc -> Expect.isFalse (proc.Result.Output.Contains("test")) (ErrorMessage.withProcessDiagnostics $"Console output {proc.Result.Output} did contain the package" proc tool args)
                 
-                ]
+                    ]
+            ])
+            testSequenced (testList "install test v1" [
+                yield! 
+                    testFixture (Fixtures.withToolExecution 
+                        true
+                        "../../../../../publish/arc-validate" 
+                        [|"-v"; "package"; "install"; "test"; "-pv"; "1.0.0"; "-pr"|]
+                        (get_gh_api_token())
+                    ) [
+                        "Exit code is 0" , 
+                            fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args)
+                        "Cache folder exists" ,  
+                            fun tool args proc -> Expect.isTrue (Directory.Exists(expected_package_cache_folder_path_preview)) (ErrorMessage.withCLIDiagnostics $"package cache folder was not created at {expected_package_cache_folder_path_preview}." tool args)
+                        "Cache exists" ,  
+                            fun tool args proc -> Expect.isTrue (File.Exists(expected_package_cache_file_path_preview)) (ErrorMessage.withCLIDiagnostics $"package cache was not created at {expected_package_cache_file_path_preview}." tool args)
+                        "Package script exists" ,  
+                            fun tool args proc -> Expect.isTrue (File.Exists(Path.Combine(expected_package_cache_folder_path_preview, "test@1.0.0.fsx"))) (ErrorMessage.withCLIDiagnostics $"package file was not installed at expected location." tool args)
+                        "Package script has correct content" ,
+                            fun tool args proc -> 
+                                Expect.equal 
+                                    (File.ReadAllText(Path.Combine(expected_package_cache_folder_path_preview, "test@1.0.0.fsx")).ReplaceLineEndings())
+                                    test_package_script_content_v1
+                                    (ErrorMessage.withCLIDiagnostics $"Package script did not have correct content" tool args)
+                    ]
+            ])
+            testSequenced (testList "list v1" [
+                yield! 
+                    testFixture (Fixtures.withToolExecution 
+                        false
+                        "../../../../../publish/arc-validate" 
+                        [|"-v"; "package"; "list";|]
+                        (get_gh_api_token())
+                    ) [
+                        "Exit code is 0 (after install)" , 
+                            fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args)
+                        "test package is listed (after install)" , 
+                            fun tool args proc -> Expect.isTrue (proc.Result.Output.Contains("test @ version 1.0.0")) (ErrorMessage.withProcessDiagnostics $"Console output {proc.Result.Output} did not contain the package" proc tool args)
+                    ]
+            ])
+            testSequenced (testList "uninstall test v1" [
+                yield! 
+                    testFixture (Fixtures.withToolExecution 
+                        false
+                        "../../../../../publish/arc-validate" 
+                        [|"-v"; "package"; "uninstall"; "test"; "-pr"|]
+                        (get_gh_api_token())
+                    ) [
+                        "Exit code is 0" , 
+                            fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args)
+                        "Cache folder still exists" ,  
+                            fun tool args proc -> Expect.isTrue (Directory.Exists(expected_package_cache_folder_path_preview)) (ErrorMessage.withCLIDiagnostics $"package cache folder was not created at {expected_package_cache_folder_path_preview}." tool args)
+                        "Cache still exists" ,  
+                            fun tool args proc -> Expect.isTrue (File.Exists(expected_package_cache_file_path_preview)) (ErrorMessage.withCLIDiagnostics $"package cache was not created at {expected_package_cache_file_path_preview}." tool args)
+                        "test package script does not exist anymore" ,  
+                            fun tool args proc -> Expect.isFalse (File.Exists(Path.Combine(expected_package_cache_folder_path_preview, "test@1.0.0.fsx"))) (ErrorMessage.withCLIDiagnostics $"package file was not uninstalled at expected location." tool args)
+                    ]
+            ])
+            testSequenced (testList "list v1" [
+                yield! 
+                    testFixture (Fixtures.withToolExecution 
+                        false
+                        "../../../../../publish/arc-validate" 
+                        [|"-v"; "package"; "list";|]
+                        (get_gh_api_token())
+                    ) [
+                        "Exit code is 0 (after uninstall)" , 
+                            fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args)
+                        "test package is not listed (after uninstall)" , 
+                            fun tool args proc -> Expect.isFalse (proc.Result.Output.Contains("test @ version 1.0.0")) (ErrorMessage.withProcessDiagnostics $"Console output {proc.Result.Output} did contain the package" proc tool args)
+                    ]
+            ])
+            testSequenced (testList "install test v2" [
+                yield! 
+                    testFixture (Fixtures.withToolExecution 
+                        true
+                        "../../../../../publish/arc-validate" 
+                        [|"-v"; "package"; "install"; "test"; "-pv"; "2.0.0"; "-pr"|]
+                        (get_gh_api_token())
+                    ) [
+                        "Exit code is 0" , 
+                            fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args)
+                        "Cache folder exists" ,  
+                            fun tool args proc -> Expect.isTrue (Directory.Exists(expected_package_cache_folder_path_preview)) (ErrorMessage.withCLIDiagnostics $"package cache folder was not created at {expected_package_cache_folder_path_preview}." tool args)
+                        "Cache exists" ,  
+                            fun tool args proc -> Expect.isTrue (File.Exists(expected_package_cache_file_path_preview)) (ErrorMessage.withCLIDiagnostics $"package cache was not created at {expected_package_cache_file_path_preview}." tool args)
+                        "Package script exists" ,  
+                            fun tool args proc -> Expect.isTrue (File.Exists(Path.Combine(expected_package_cache_folder_path_preview, "test@2.0.0.fsx"))) (ErrorMessage.withCLIDiagnostics $"package file was not installed at expected location." tool args)
+                        "Package script has correct content" ,
+                            fun tool args proc -> 
+                                Expect.equal 
+                                    (File.ReadAllText(Path.Combine(expected_package_cache_folder_path_preview, "test@2.0.0.fsx")).ReplaceLineEndings())
+                                    test_package_script_content_v2
+                                    (ErrorMessage.withCLIDiagnostics $"Package script did not have correct content" tool args)
+                    ]
+            ])
+            testSequenced (testList "list v2" [
+                yield! 
+                    testFixture (Fixtures.withToolExecution 
+                        false
+                        "../../../../../publish/arc-validate" 
+                        [|"-v"; "package"; "list";|]
+                        (get_gh_api_token())
+                    ) [
+                        "Exit code is 0 (after install)" , 
+                            fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args)
+                        "test package is listed (after install)" , 
+                            fun tool args proc -> Expect.isTrue (proc.Result.Output.Contains("test @ version 2.0.0")) (ErrorMessage.withProcessDiagnostics $"Console output {proc.Result.Output} did not contain the package" proc tool args)
+                    ]
+            ])
+            testSequenced (testList "uninstall test v2" [
+                yield! 
+                    testFixture (Fixtures.withToolExecution 
+                        false
+                        "../../../../../publish/arc-validate" 
+                        [|"-v"; "package"; "uninstall"; "test"; "-pr"|]
+                        (get_gh_api_token())
+                    ) [
+                        "Exit code is 0" , 
+                            fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args)
+                        "Cache folder still exists" ,  
+                            fun tool args proc -> Expect.isTrue (Directory.Exists(expected_package_cache_folder_path_preview)) (ErrorMessage.withCLIDiagnostics $"package cache folder was not created at {expected_package_cache_folder_path_preview}." tool args)
+                        "Cache still exists" ,  
+                            fun tool args proc -> Expect.isTrue (File.Exists(expected_package_cache_file_path_preview)) (ErrorMessage.withCLIDiagnostics $"package cache was not created at {expected_package_cache_file_path_preview}." tool args)
+                        "test package script does not exist anymore" ,  
+                            fun tool args proc -> Expect.isFalse (File.Exists(Path.Combine(expected_package_cache_folder_path_preview, "test@2.0.0.fsx"))) (ErrorMessage.withCLIDiagnostics $"package file was not uninstalled at expected location." tool args)
+                    ]
+            ])
+            testSequenced (testList "list v2" [
+                yield! 
+                    testFixture (Fixtures.withToolExecution 
+                        false
+                        "../../../../../publish/arc-validate" 
+                        [|"-v"; "package"; "list";|]
+                        (get_gh_api_token())
+                    ) [
+                        "Exit code is 0 (after uninstall)" , 
+                            fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args)
+                        "test package is not listed (after uninstall)" , 
+                            fun tool args proc -> Expect.isFalse (proc.Result.Output.Contains("test @ version 2.0.0")) (ErrorMessage.withProcessDiagnostics $"Console output {proc.Result.Output} did contain the package" proc tool args)
+                    ]
+            ])
+            testSequenced (testList "update-index" [
+                yield! 
+                    testFixture (Fixtures.withToolExecution 
+                        false
+                        "../../../../../publish/arc-validate" 
+                        [|"-v"; "package"; "update-index"|]
+                        (get_gh_api_token())
+                    ) [
+                        "Exit code is 0" , 
+                            fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args)
+                    ]
+            ])
         ])
-        testSequenced (testList "install test v1" [
-            yield! 
-                testFixture (Fixtures.withToolExecution 
-                    true
-                    "../../../../../publish/arc-validate" 
-                    [|"-v"; "package"; "install"; "test"; "-pv"; "1.0.0"; "-pr"|]
-                    (get_gh_api_token())
-                ) [
-                    "Exit code is 0" , 
-                        fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args)
-                    "Cache folder exists" ,  
-                        fun tool args proc -> Expect.isTrue (Directory.Exists(expected_package_cache_folder_path_preview)) (ErrorMessage.withCLIDiagnostics $"package cache folder was not created at {expected_package_cache_folder_path_preview}." tool args)
-                    "Cache exists" ,  
-                        fun tool args proc -> Expect.isTrue (File.Exists(expected_package_cache_file_path_preview)) (ErrorMessage.withCLIDiagnostics $"package cache was not created at {expected_package_cache_file_path_preview}." tool args)
-                    "Package script exists" ,  
-                        fun tool args proc -> Expect.isTrue (File.Exists(Path.Combine(expected_package_cache_folder_path_preview, "test@1.0.0.fsx"))) (ErrorMessage.withCLIDiagnostics $"package file was not installed at expected location." tool args)
-                    "Package script has correct content" ,
-                        fun tool args proc -> 
-                            Expect.equal 
-                                (File.ReadAllText(Path.Combine(expected_package_cache_folder_path_preview, "test@1.0.0.fsx")).ReplaceLineEndings())
-                                test_package_script_content_v1
-                                (ErrorMessage.withCLIDiagnostics $"Package script did not have correct content" tool args)
-                ]
-        ])
-        testSequenced (testList "list v1" [
-            yield! 
-                testFixture (Fixtures.withToolExecution 
-                    false
-                    "../../../../../publish/arc-validate" 
-                    [|"-v"; "package"; "list";|]
-                    (get_gh_api_token())
-                ) [
-                    "Exit code is 0 (after install)" , 
-                        fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args)
-                    "test package is listed (after install)" , 
-                        fun tool args proc -> Expect.isTrue (proc.Result.Output.Contains("test @ version 1.0.0")) (ErrorMessage.withProcessDiagnostics $"Console output {proc.Result.Output} did not contain the package" proc tool args)
-                ]
-        ])
-        testSequenced (testList "uninstall test v1" [
-            yield! 
-                testFixture (Fixtures.withToolExecution 
-                    false
-                    "../../../../../publish/arc-validate" 
-                    [|"-v"; "package"; "uninstall"; "test"; "-pr"|]
-                    (get_gh_api_token())
-                ) [
-                    "Exit code is 0" , 
-                        fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args)
-                    "Cache folder still exists" ,  
-                        fun tool args proc -> Expect.isTrue (Directory.Exists(expected_package_cache_folder_path_preview)) (ErrorMessage.withCLIDiagnostics $"package cache folder was not created at {expected_package_cache_folder_path_preview}." tool args)
-                    "Cache still exists" ,  
-                        fun tool args proc -> Expect.isTrue (File.Exists(expected_package_cache_file_path_preview)) (ErrorMessage.withCLIDiagnostics $"package cache was not created at {expected_package_cache_file_path_preview}." tool args)
-                    "test package script does not exist anymore" ,  
-                        fun tool args proc -> Expect.isFalse (File.Exists(Path.Combine(expected_package_cache_folder_path_preview, "test@1.0.0.fsx"))) (ErrorMessage.withCLIDiagnostics $"package file was not uninstalled at expected location." tool args)
-                ]
-        ])
-        testSequenced (testList "list v1" [
-            yield! 
-                testFixture (Fixtures.withToolExecution 
-                    false
-                    "../../../../../publish/arc-validate" 
-                    [|"-v"; "package"; "list";|]
-                    (get_gh_api_token())
-                ) [
-                    "Exit code is 0 (after uninstall)" , 
-                        fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args)
-                    "test package is not listed (after uninstall)" , 
-                        fun tool args proc -> Expect.isFalse (proc.Result.Output.Contains("test @ version 1.0.0")) (ErrorMessage.withProcessDiagnostics $"Console output {proc.Result.Output} did contain the package" proc tool args)
-                ]
-        ])
-        testSequenced (testList "install test v2" [
-            yield! 
-                testFixture (Fixtures.withToolExecution 
-                    true
-                    "../../../../../publish/arc-validate" 
-                    [|"-v"; "package"; "install"; "test"; "-pv"; "2.0.0"; "-pr"|]
-                    (get_gh_api_token())
-                ) [
-                    "Exit code is 0" , 
-                        fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args)
-                    "Cache folder exists" ,  
-                        fun tool args proc -> Expect.isTrue (Directory.Exists(expected_package_cache_folder_path_preview)) (ErrorMessage.withCLIDiagnostics $"package cache folder was not created at {expected_package_cache_folder_path_preview}." tool args)
-                    "Cache exists" ,  
-                        fun tool args proc -> Expect.isTrue (File.Exists(expected_package_cache_file_path_preview)) (ErrorMessage.withCLIDiagnostics $"package cache was not created at {expected_package_cache_file_path_preview}." tool args)
-                    "Package script exists" ,  
-                        fun tool args proc -> Expect.isTrue (File.Exists(Path.Combine(expected_package_cache_folder_path_preview, "test@2.0.0.fsx"))) (ErrorMessage.withCLIDiagnostics $"package file was not installed at expected location." tool args)
-                    "Package script has correct content" ,
-                        fun tool args proc -> 
-                            Expect.equal 
-                                (File.ReadAllText(Path.Combine(expected_package_cache_folder_path_preview, "test@2.0.0.fsx")).ReplaceLineEndings())
-                                test_package_script_content_v2
-                                (ErrorMessage.withCLIDiagnostics $"Package script did not have correct content" tool args)
-                ]
-        ])
-        testSequenced (testList "list v2" [
-            yield! 
-                testFixture (Fixtures.withToolExecution 
-                    false
-                    "../../../../../publish/arc-validate" 
-                    [|"-v"; "package"; "list";|]
-                    (get_gh_api_token())
-                ) [
-                    "Exit code is 0 (after install)" , 
-                        fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args)
-                    "test package is listed (after install)" , 
-                        fun tool args proc -> Expect.isTrue (proc.Result.Output.Contains("test @ version 2.0.0")) (ErrorMessage.withProcessDiagnostics $"Console output {proc.Result.Output} did not contain the package" proc tool args)
-                ]
-        ])
-        testSequenced (testList "uninstall test v2" [
-            yield! 
-                testFixture (Fixtures.withToolExecution 
-                    false
-                    "../../../../../publish/arc-validate" 
-                    [|"-v"; "package"; "uninstall"; "test"; "-pr"|]
-                    (get_gh_api_token())
-                ) [
-                    "Exit code is 0" , 
-                        fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args)
-                    "Cache folder still exists" ,  
-                        fun tool args proc -> Expect.isTrue (Directory.Exists(expected_package_cache_folder_path_preview)) (ErrorMessage.withCLIDiagnostics $"package cache folder was not created at {expected_package_cache_folder_path_preview}." tool args)
-                    "Cache still exists" ,  
-                        fun tool args proc -> Expect.isTrue (File.Exists(expected_package_cache_file_path_preview)) (ErrorMessage.withCLIDiagnostics $"package cache was not created at {expected_package_cache_file_path_preview}." tool args)
-                    "test package script does not exist anymore" ,  
-                        fun tool args proc -> Expect.isFalse (File.Exists(Path.Combine(expected_package_cache_folder_path_preview, "test@2.0.0.fsx"))) (ErrorMessage.withCLIDiagnostics $"package file was not uninstalled at expected location." tool args)
-                ]
-        ])
-        testSequenced (testList "list v2" [
-            yield! 
-                testFixture (Fixtures.withToolExecution 
-                    false
-                    "../../../../../publish/arc-validate" 
-                    [|"-v"; "package"; "list";|]
-                    (get_gh_api_token())
-                ) [
-                    "Exit code is 0 (after uninstall)" , 
-                        fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args)
-                    "test package is not listed (after uninstall)" , 
-                        fun tool args proc -> Expect.isFalse (proc.Result.Output.Contains("test @ version 2.0.0")) (ErrorMessage.withProcessDiagnostics $"Console output {proc.Result.Output} did contain the package" proc tool args)
-                ]
-        ])
-        testSequenced (testList "update-index" [
-            yield! 
-                testFixture (Fixtures.withToolExecution 
-                    false
-                    "../../../../../publish/arc-validate" 
-                    [|"-v"; "package"; "update-index"|]
-                    (get_gh_api_token())
-                ) [
-                    "Exit code is 0" , 
-                        fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args)
-                ]
+        testSequenced (testList "arc-validate release package" [
+            testSequenced (testList "install test v3" [
+                yield! 
+                    testFixture (Fixtures.withToolExecution 
+                        true
+                        "../../../../../publish/arc-validate" 
+                        [|"-v"; "package"; "install"; "test"; "-pv"; "3.0.0"|]
+                        None
+                    ) [
+                        "Exit code is 0" , 
+                            fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args)
+                        "Cache folder exists" ,  
+                            fun tool args proc -> Expect.isTrue (Directory.Exists(expected_package_cache_folder_path_release)) (ErrorMessage.withCLIDiagnostics $"package cache folder was not created at {expected_package_cache_folder_path_release}." tool args)
+                        "Cache exists" ,  
+                            fun tool args proc -> Expect.isTrue (File.Exists(expected_package_cache_file_path_release)) (ErrorMessage.withCLIDiagnostics $"package cache was not created at {expected_package_cache_file_path_release}." tool args)
+                        "Package script exists" ,  
+                            fun tool args proc -> Expect.isTrue (File.Exists(Path.Combine(expected_package_cache_folder_path_release, "test.fsx"))) (ErrorMessage.withCLIDiagnostics $"package file was not installed at expected location." tool args)
+                        "Package script has correct content" ,
+                            fun tool args proc -> 
+                                Expect.equal 
+                                    (File.ReadAllText(Path.Combine(expected_package_cache_folder_path_release, "test.fsx")).ReplaceLineEndings())
+                                    test_package_script_content_v3
+                                    (ErrorMessage.withCLIDiagnostics $"Package script did not have correct content" tool args)
+                    ]
+            ])
+            
+            testSequenced (testList "uninstall test v3" [
+                yield! 
+                    testFixture (Fixtures.withToolExecution 
+                        false
+                        "../../../../../publish/arc-validate" 
+                        [|"-v"; "package"; "uninstall"; "test"|]
+                        None
+                    ) [
+                        "Exit code is 0" , 
+                            fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args)
+                        "Cache folder still exists" ,  
+                            fun tool args proc -> Expect.isTrue (Directory.Exists(expected_package_cache_folder_path_release)) (ErrorMessage.withCLIDiagnostics $"package cache folder was not created at {expected_package_cache_folder_path_release}." tool args)
+                        "Cache still exists" ,  
+                            fun tool args proc -> Expect.isTrue (File.Exists(expected_package_cache_file_path_release)) (ErrorMessage.withCLIDiagnostics $"package cache was not created at {expected_package_cache_file_path_release}." tool args)
+                        "test package script does not exist anymore" ,  
+                            fun tool args proc -> Expect.isFalse (File.Exists(Path.Combine(expected_package_cache_folder_path_release, "test.fsx"))) (ErrorMessage.withCLIDiagnostics $"package file was not uninstalled at expected location." tool args)
+                    ]
+            ])
         ])
     ])

--- a/tests/arc-validate.Tests/CLITests/ValidateCommandTests.fs
+++ b/tests/arc-validate.Tests/CLITests/ValidateCommandTests.fs
@@ -22,7 +22,7 @@ let ``ValidateCommand CLI Tests`` =
                 testFixture (Fixtures.withToolExecution 
                     true
                     "../../../../../publish/arc-validate" 
-                    [|"-v"; "package"; "install"; "test"; "-pv"; "2.0.0"|]
+                    [|"-v"; "package"; "install"; "test"; "-pv"; "2.0.0"; "-pr"|]
                     (get_gh_api_token())
                 ) [
                     "Package script exists after running package install test" ,  
@@ -53,7 +53,7 @@ let ``ValidateCommand CLI Tests`` =
                 testFixture (Fixtures.withToolExecution 
                     true
                     "../../../../../publish/arc-validate" 
-                    [|"-v"; "package"; "install"; "test";|]
+                    [|"-v"; "package"; "install"; "test"; "-pr"|]
                     (get_gh_api_token())
                 ) [
                     "Package script exists after running package install test" ,  

--- a/tests/arc-validate.Tests/CLITests/ValidateCommandTests.fs
+++ b/tests/arc-validate.Tests/CLITests/ValidateCommandTests.fs
@@ -17,7 +17,7 @@ open JUnit
 [<Tests>]
 let ``ValidateCommand CLI Tests`` =
     testSequenced (testList "arc-validate validate" [
-        testSequenced (testList "package test -pv 2 -i fixtures/arcs/inveniotestarc" [
+        testSequenced (testList "package test -pv 2 -pr -i fixtures/arcs/inveniotestarc" [
             yield! 
                 testFixture (Fixtures.withToolExecution 
                     true
@@ -25,14 +25,17 @@ let ``ValidateCommand CLI Tests`` =
                     [|"-v"; "package"; "install"; "test"; "-pv"; "2.0.0"; "-pr"|]
                     (get_gh_api_token())
                 ) [
-                    "Package script exists after running package install test" ,  
+                    "Package script exists in preview cache after running package install test" ,  
                         fun tool args proc -> Expect.isTrue (File.Exists(Path.Combine(expected_package_cache_folder_path_preview, "test@2.0.0.fsx")))  (ErrorMessage.withCLIDiagnostics "package file was not installed at expected location" tool args )
+                    "Package script does not exist in avpr cache after running package install test" ,  
+                        fun tool args proc -> Expect.isFalse (File.Exists(Path.Combine(expected_package_cache_folder_path_release, "test@2.0.0.fsx")))  (ErrorMessage.withCLIDiagnostics "package file was not installed at expected location" tool args )
+                
                 ]
             yield! 
                 testFixture (Fixtures.withToolExecution 
                     false
                     "../../../../../publish/arc-validate" 
-                    [|"-v"; "validate"; "-p"; "test"; "-pv"; "2.0.0"; "-i"; "fixtures/arcs/inveniotestarc"|]
+                    [|"-v"; "validate"; "-pr"; "-p"; "test"; "-pv"; "2.0.0"; "-pr"; "-i"; "fixtures/arcs/inveniotestarc"|]
                     (get_gh_api_token())
                 ) [
                     "Exit code is 0" , 
@@ -48,7 +51,7 @@ let ``ValidateCommand CLI Tests`` =
                             Expect.isTrue (File.Exists(".arc-validate-results/test/validation_report.xml")) (ErrorMessage.withProcessDiagnostics $".arc-validate-results/test/validation_report.xml does not exist in {System.Environment.CurrentDirectory}" proc tool args )
                     ]
         ])
-        testSequenced (testList "package test -i fixtures/arcs/inveniotestarc" [
+        testSequenced (testList "package test -pr -i fixtures/arcs/inveniotestarc" [
             yield! 
                 testFixture (Fixtures.withToolExecution 
                     true
@@ -56,14 +59,17 @@ let ``ValidateCommand CLI Tests`` =
                     [|"-v"; "package"; "install"; "test"; "-pr"|]
                     (get_gh_api_token())
                 ) [
-                    "Package script exists after running package install test" ,  
+                    "Package script exists in preview cache after running package install test" ,  
                         fun tool args proc -> Expect.isTrue (File.Exists(Path.Combine(expected_package_cache_folder_path_preview, "test@4.0.0.fsx")))  (ErrorMessage.withCLIDiagnostics "package file was not installed at expected location" tool args )
+                    "Package script does not exist in avpr cache after running package install test" ,  
+                        fun tool args proc -> Expect.isFalse (File.Exists(Path.Combine(expected_package_cache_folder_path_release, "test@4.0.0.fsx")))  (ErrorMessage.withCLIDiagnostics "package file was not installed at expected location" tool args )
+                
                 ]
             yield! 
                 testFixture (Fixtures.withToolExecution 
                     false
                     "../../../../../publish/arc-validate" 
-                    [|"-v"; "validate"; "-p"; "test"; "-i"; "fixtures/arcs/inveniotestarc"|]
+                    [|"-v"; "validate"; "-p"; "test"; "-pr"; "-i"; "fixtures/arcs/inveniotestarc"|]
                     (get_gh_api_token())
                 ) [
                     "Exit code is 0" , 

--- a/tests/arc-validate.Tests/CLITests/ValidateCommandTests.fs
+++ b/tests/arc-validate.Tests/CLITests/ValidateCommandTests.fs
@@ -17,71 +17,150 @@ open JUnit
 [<Tests>]
 let ``ValidateCommand CLI Tests`` =
     testSequenced (testList "arc-validate validate" [
-        testSequenced (testList "package test -pv 2 -pr -i fixtures/arcs/inveniotestarc" [
-            yield! 
-                testFixture (Fixtures.withToolExecution 
-                    true
-                    "../../../../../publish/arc-validate" 
-                    [|"-v"; "package"; "install"; "test"; "-pv"; "2.0.0"; "-pr"|]
-                    (get_gh_api_token())
-                ) [
-                    "Package script exists in preview cache after running package install test" ,  
-                        fun tool args proc -> Expect.isTrue (File.Exists(Path.Combine(expected_package_cache_folder_path_preview, "test@2.0.0.fsx")))  (ErrorMessage.withCLIDiagnostics "package file was not installed at expected location" tool args )
-                    "Package script does not exist in avpr cache after running package install test" ,  
-                        fun tool args proc -> Expect.isFalse (File.Exists(Path.Combine(expected_package_cache_folder_path_release, "test@2.0.0.fsx")))  (ErrorMessage.withCLIDiagnostics "package file was not installed at expected location" tool args )
+        testSequenced (testList "preview" [
+            testSequenced (testList "package test version 2" [
+                // run:
+                // - arc-validate --verbose package install test -v 2.0.0 --preview
+                // - arc-validate validate -p test -v 2.0.0 --preview -i fixtures/arcs/inveniotestarc
+                yield! 
+                    testFixture (Fixtures.withToolExecution 
+                        true
+                        "../../../../../publish/arc-validate" 
+                        [|"--verbose"; "package"; "install"; "test"; "-v"; "2.0.0"; "--preview"|]
+                        (get_gh_api_token())
+                    ) [
+                        "Package script exists in preview cache after running package install test" ,  
+                            fun tool args proc -> Expect.isTrue (File.Exists(Path.Combine(expected_package_cache_folder_path_preview, "test@2.0.0.fsx")))  (ErrorMessage.withCLIDiagnostics "package file was not installed at expected location" tool args )
+                        "Package script does not exist in avpr cache after running package install test" ,  
+                            fun tool args proc -> Expect.isFalse (File.Exists(Path.Combine(expected_package_cache_folder_path_release, "test@2.0.0.fsx")))  (ErrorMessage.withCLIDiagnostics "package file was not installed at expected location" tool args )
                 
-                ]
-            yield! 
-                testFixture (Fixtures.withToolExecution 
-                    false
-                    "../../../../../publish/arc-validate" 
-                    [|"-v"; "validate"; "-pr"; "-p"; "test"; "-pv"; "2.0.0"; "-pr"; "-i"; "fixtures/arcs/inveniotestarc"|]
-                    (get_gh_api_token())
-                ) [
-                    "Exit code is 0" , 
-                        fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args )
-                    "Console output does not indicate that package is not installed" , 
-                        fun tool args proc -> Expect.isFalse (proc.Result.Output.Contains("Package test not installed. You can run run arc-validate package install ")) (ErrorMessage.withProcessDiagnostics "incorrect console output" proc tool args )
-                    "Console Output is correct" ,
-                        fun tool args proc -> Expect.isTrue (proc.Result.Output.Contains("If you can read this in your console, you successfully executed test package v2.0.0!")) (ErrorMessage.withProcessDiagnostics "incorrect console output" proc tool args )
-                    "Ouptput files exist",
-                        fun tool args proc -> 
-                            Expect.isTrue (Directory.Exists(".arc-validate-results")) (ErrorMessage.withProcessDiagnostics $".arc-validate-results does not exist in {System.Environment.CurrentDirectory}" proc tool args )
-                            Expect.isTrue (File.Exists(".arc-validate-results/test/badge.svg")) (ErrorMessage.withProcessDiagnostics $".arc-validate-results/test/badge.svg does not exist in {System.Environment.CurrentDirectory}" proc tool args )
-                            Expect.isTrue (File.Exists(".arc-validate-results/test/validation_report.xml")) (ErrorMessage.withProcessDiagnostics $".arc-validate-results/test/validation_report.xml does not exist in {System.Environment.CurrentDirectory}" proc tool args )
                     ]
-        ])
-        testSequenced (testList "package test -pr -i fixtures/arcs/inveniotestarc" [
-            yield! 
-                testFixture (Fixtures.withToolExecution 
-                    true
-                    "../../../../../publish/arc-validate" 
-                    [|"-v"; "package"; "install"; "test"; "-pr"|]
-                    (get_gh_api_token())
-                ) [
-                    "Package script exists in preview cache after running package install test" ,  
-                        fun tool args proc -> Expect.isTrue (File.Exists(Path.Combine(expected_package_cache_folder_path_preview, "test@4.0.0.fsx")))  (ErrorMessage.withCLIDiagnostics "package file was not installed at expected location" tool args )
-                    "Package script does not exist in avpr cache after running package install test" ,  
-                        fun tool args proc -> Expect.isFalse (File.Exists(Path.Combine(expected_package_cache_folder_path_release, "test@4.0.0.fsx")))  (ErrorMessage.withCLIDiagnostics "package file was not installed at expected location" tool args )
+                yield! 
+                    testFixture (Fixtures.withToolExecution 
+                        false
+                        "../../../../../publish/arc-validate" 
+                        [|"--verbose"; "validate"; "-p"; "test"; "-v"; "2.0.0"; "--preview"; "-i"; "fixtures/arcs/inveniotestarc"|]
+                        (get_gh_api_token())
+                    ) [
+                        "Exit code is 0" , 
+                            fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args )
+                        "Console output does not indicate that package is not installed" , 
+                            fun tool args proc -> Expect.isFalse (proc.Result.Output.Contains("Package test not installed. You can run run arc-validate package install ")) (ErrorMessage.withProcessDiagnostics "incorrect console output" proc tool args )
+                        "Console Output is correct" ,
+                            fun tool args proc -> Expect.isTrue (proc.Result.Output.Contains("If you can read this in your console, you successfully executed test package v2.0.0!")) (ErrorMessage.withProcessDiagnostics "incorrect console output" proc tool args )
+                        "Ouptput files exist",
+                            fun tool args proc -> 
+                                Expect.isTrue (Directory.Exists(".arc-validate-results")) (ErrorMessage.withProcessDiagnostics $".arc-validate-results does not exist in {System.Environment.CurrentDirectory}" proc tool args )
+                                Expect.isTrue (File.Exists(".arc-validate-results/test/badge.svg")) (ErrorMessage.withProcessDiagnostics $".arc-validate-results/test/badge.svg does not exist in {System.Environment.CurrentDirectory}" proc tool args )
+                                Expect.isTrue (File.Exists(".arc-validate-results/test/validation_report.xml")) (ErrorMessage.withProcessDiagnostics $".arc-validate-results/test/validation_report.xml does not exist in {System.Environment.CurrentDirectory}" proc tool args )
+                        ]
+            ])
+            testSequenced (testList "package test version latest" [
+                // run:
+                // - arc-validate --verbose package install test --preview
+                // - arc-validate validate -p test --preview -i fixtures/arcs/inveniotestarc
+                yield! 
+                    testFixture (Fixtures.withToolExecution 
+                        true
+                        "../../../../../publish/arc-validate" 
+                        [|"--verbose"; "package"; "install"; "test"; "--preview"|]
+                        (get_gh_api_token())
+                    ) [
+                        "Package script exists in preview cache after running package install test" ,  
+                            fun tool args proc -> Expect.isTrue (File.Exists(Path.Combine(expected_package_cache_folder_path_preview, "test@999.999.999.fsx")))  (ErrorMessage.withCLIDiagnostics "package file was not installed at expected location" tool args )
+                        "Package script does not exist in avpr cache after running package install test" ,  
+                            fun tool args proc -> Expect.isFalse (File.Exists(Path.Combine(expected_package_cache_folder_path_release, "test@999.999.999.fsx")))  (ErrorMessage.withCLIDiagnostics "package file was not installed at expected location" tool args )
                 
-                ]
-            yield! 
-                testFixture (Fixtures.withToolExecution 
-                    false
-                    "../../../../../publish/arc-validate" 
-                    [|"-v"; "validate"; "-p"; "test"; "-pr"; "-i"; "fixtures/arcs/inveniotestarc"|]
-                    (get_gh_api_token())
-                ) [
-                    "Exit code is 0" , 
-                        fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args )
-                    "Console output does not indicate that package is not installed" , 
-                        fun tool args proc -> Expect.isFalse (proc.Result.Output.Contains("Package test not installed. You can run run arc-validate package install ")) (ErrorMessage.withProcessDiagnostics "incorrect console output" proc tool args )
-                    "Console Output is correct" ,
-                        fun tool args proc -> Expect.isTrue (proc.Result.Output.Contains("If you can read this in your console, you successfully executed test package v4.0.0!")) (ErrorMessage.withProcessDiagnostics "incorrect console output" proc tool args )
-
                     ]
-        ])
+                yield! 
+                    testFixture (Fixtures.withToolExecution 
+                        false
+                        "../../../../../publish/arc-validate" 
+                        [|"--verbose"; "validate"; "-p"; "test"; "--preview"; "-i"; "fixtures/arcs/inveniotestarc"|]
+                        (get_gh_api_token())
+                    ) [
+                        "Exit code is 0" , 
+                            fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args )
+                        "Console output does not indicate that package is not installed" , 
+                            fun tool args proc -> Expect.isFalse (proc.Result.Output.Contains("Package test not installed. You can run run arc-validate package install ")) (ErrorMessage.withProcessDiagnostics "incorrect console output" proc tool args )
+                        "Console Output is correct" ,
+                            fun tool args proc -> Expect.isTrue (proc.Result.Output.Contains("If you can read this in your console, you successfully executed preview test package v999.999.999!")) (ErrorMessage.withProcessDiagnostics "incorrect console output" proc tool args )
 
+                        ]
+                ])
+            ])
+        testSequenced (testList "avpr" [
+            testSequenced (testList "package test version 2" [
+                yield! 
+                // run:
+                // - arc-validate --verbose package install test -v 2.0.0
+                // - arc-validate validate -p test -v 2.0.0 --preview -i fixtures/arcs/inveniotestarc
+                    testFixture (Fixtures.withToolExecution 
+                        true
+                        "../../../../../publish/arc-validate" 
+                        [|"--verbose"; "package"; "install"; "test"; "-v"; "2.0.0"|]
+                        (get_gh_api_token())
+                    ) [
+                        "Package script exists in avpr cache after running package install test" ,  
+                            fun tool args proc -> Expect.isTrue (File.Exists(Path.Combine(expected_package_cache_folder_path_release, "test@2.0.0.fsx")))  (ErrorMessage.withCLIDiagnostics "package file was not installed at expected location" tool args )
+                        "Package script does not exist in preview cache after running package install test" ,  
+                            fun tool args proc -> Expect.isFalse (File.Exists(Path.Combine(expected_package_cache_folder_path_preview, "test@2.0.0.fsx")))  (ErrorMessage.withCLIDiagnostics "package file was not installed at expected location" tool args )
+                
+                    ]
+                yield! 
+                    testFixture (Fixtures.withToolExecution 
+                        false
+                        "../../../../../publish/arc-validate" 
+                        [|"--verbose"; "validate"; "-p"; "test"; "-v"; "2.0.0"; "-i"; "fixtures/arcs/inveniotestarc"|]
+                        (get_gh_api_token())
+                    ) [
+                        "Exit code is 0" , 
+                            fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args )
+                        "Console output does not indicate that package is not installed" , 
+                            fun tool args proc -> Expect.isFalse (proc.Result.Output.Contains("Package test not installed. You can run run arc-validate package install ")) (ErrorMessage.withProcessDiagnostics "incorrect console output" proc tool args )
+                        "Console Output is correct" ,
+                            fun tool args proc -> Expect.isTrue (proc.Result.Output.Contains("If you can read this in your console, you successfully executed test package v2.0.0!")) (ErrorMessage.withProcessDiagnostics "incorrect console output" proc tool args )
+                        "Ouptput files exist",
+                            fun tool args proc -> 
+                                Expect.isTrue (Directory.Exists(".arc-validate-results")) (ErrorMessage.withProcessDiagnostics $".arc-validate-results does not exist in {System.Environment.CurrentDirectory}" proc tool args )
+                                Expect.isTrue (File.Exists(".arc-validate-results/test/badge.svg")) (ErrorMessage.withProcessDiagnostics $".arc-validate-results/test/badge.svg does not exist in {System.Environment.CurrentDirectory}" proc tool args )
+                                Expect.isTrue (File.Exists(".arc-validate-results/test/validation_report.xml")) (ErrorMessage.withProcessDiagnostics $".arc-validate-results/test/validation_report.xml does not exist in {System.Environment.CurrentDirectory}" proc tool args )
+                        ]
+            ])
+            testSequenced (testList "package test version latest" [
+                // run:
+                // - arc-validate --verbose package install test
+                // - arc-validate validate -p test -i fixtures/arcs/inveniotestarc
+                yield! 
+                    testFixture (Fixtures.withToolExecution 
+                        true
+                        "../../../../../publish/arc-validate" 
+                        [|"--verbose"; "package"; "install"; "test";|]
+                        (get_gh_api_token())
+                    ) [
+                        "Package script exists in avpr cache after running package install test" ,  
+                            fun tool args proc -> Expect.isTrue (File.Exists(Path.Combine(expected_package_cache_folder_path_release, "test@3.0.0.fsx")))  (ErrorMessage.withCLIDiagnostics "package file was not installed at expected location" tool args )
+                        "Package script does not exist in preview cache after running package install test" ,  
+                            fun tool args proc -> Expect.isFalse (File.Exists(Path.Combine(expected_package_cache_folder_path_preview, "test@3.0.0.fsx")))  (ErrorMessage.withCLIDiagnostics "package file was not installed at expected location" tool args )
+                
+                    ]
+                yield! 
+                    testFixture (Fixtures.withToolExecution 
+                        false
+                        "../../../../../publish/arc-validate" 
+                        [|"--verbose"; "validate"; "-p"; "test"; "-i"; "fixtures/arcs/inveniotestarc"|]
+                        (get_gh_api_token())
+                    ) [
+                        "Exit code is 0" , 
+                            fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args )
+                        "Console output does not indicate that package is not installed" , 
+                            fun tool args proc -> Expect.isFalse (proc.Result.Output.Contains("Package test not installed. You can run run arc-validate package install ")) (ErrorMessage.withProcessDiagnostics "incorrect console output" proc tool args )
+                        "Console Output is correct" ,
+                            fun tool args proc -> Expect.isTrue (proc.Result.Output.Contains("If you can read this in your console, you successfully executed test package v3.0.0!")) (ErrorMessage.withProcessDiagnostics "incorrect console output" proc tool args )
+
+                        ]
+                ])
+            ])
         //        printfn "%s" (Path.GetFullPath("fixtures/arcs/inveniotestarc"))
 
         //        let proc = runTool "../../../../../publish/arc-validate" [|"validate"; "-i"; "fixtures/arcs/inveniotestarc"|] 

--- a/tests/arc-validate.Tests/CLITests/ValidateCommandTests.fs
+++ b/tests/arc-validate.Tests/CLITests/ValidateCommandTests.fs
@@ -57,7 +57,7 @@ let ``ValidateCommand CLI Tests`` =
                     (get_gh_api_token())
                 ) [
                     "Package script exists after running package install test" ,  
-                        fun tool args proc -> Expect.isTrue (File.Exists(Path.Combine(expected_package_cache_folder_path_preview, "test@3.0.0.fsx")))  (ErrorMessage.withCLIDiagnostics "package file was not installed at expected location" tool args )
+                        fun tool args proc -> Expect.isTrue (File.Exists(Path.Combine(expected_package_cache_folder_path_preview, "test@4.0.0.fsx")))  (ErrorMessage.withCLIDiagnostics "package file was not installed at expected location" tool args )
                 ]
             yield! 
                 testFixture (Fixtures.withToolExecution 
@@ -71,7 +71,7 @@ let ``ValidateCommand CLI Tests`` =
                     "Console output does not indicate that package is not installed" , 
                         fun tool args proc -> Expect.isFalse (proc.Result.Output.Contains("Package test not installed. You can run run arc-validate package install ")) (ErrorMessage.withProcessDiagnostics "incorrect console output" proc tool args )
                     "Console Output is correct" ,
-                        fun tool args proc -> Expect.isTrue (proc.Result.Output.Contains("If you can read this in your console, you successfully executed test package v3.0.0!")) (ErrorMessage.withProcessDiagnostics "incorrect console output" proc tool args )
+                        fun tool args proc -> Expect.isTrue (proc.Result.Output.Contains("If you can read this in your console, you successfully executed test package v4.0.0!")) (ErrorMessage.withProcessDiagnostics "incorrect console output" proc tool args )
 
                     ]
         ])

--- a/tests/arc-validate.Tests/ReferenceObjects.fs
+++ b/tests/arc-validate.Tests/ReferenceObjects.fs
@@ -80,3 +80,47 @@ validationCases
     basePath = System.Environment.CurrentDirectory,
     packageName = "test"
 )"""                                    .ReplaceLineEndings()
+
+let test_package_script_content_v3 = """(*
+---
+Name: test
+MajorVersion: 3
+MinorVersion: 0
+PatchVersion: 0
+Publish: true
+Summary: this package is here for testing purposes only.
+Description: this package is here for testing purposes only.
+Authors:
+  - FullName: John Doe
+    Email: j@d.com
+    Affiliation: University of Nowhere
+    AffiliationLink: https://nowhere.edu
+  - FullName: Jane Doe
+    Email: jj@d.com
+    Affiliation: University of Somewhere
+    AffiliationLink: https://somewhere.edu
+Tags:
+  - Name: validation
+  - Name: my-package
+  - Name: thing
+ReleaseNotes: "add authors and tags for further testing"
+---
+*)
+ 
+// this file is intended for testing purposes only.
+printfn "If you can read this in your console, you successfully executed test package v3.0.0!" 
+
+#r "nuget: ARCExpect, 1.0.1"
+
+open ARCExpect
+open Expecto
+
+let validationCases = testList "test" [
+    test "yes" {Expect.equal 1 1 "yes"}
+]
+
+validationCases
+|> Execute.ValidationPipeline(
+    basePath = System.Environment.CurrentDirectory,
+    packageName = "test"
+)"""                                    .ReplaceLineEndings()


### PR DESCRIPTION
Currently, only packages hosted on github via https://github.com/nfdi4plants/arc-validate-package-registry/releases/tag/preview-index are used in the cli tool.

This PR adds support for installing packages provided by our AVPR web api at https://avpr.nfdi4plants.org 