### PR TITLE
Add function to validate against existence of non-section key CvParam

### DIFF
--- a/src/ARCExpect/ValidationFunctions.fs
+++ b/src/ARCExpect/ValidationFunctions.fs
@@ -145,6 +145,19 @@ module Validate =
                 |> Expecto.Tests.failtestNoStackf "%s"
 
         /// <summary>
+        /// Validates if at least one Param with the expected term in the given collection exists, which is not a metadata section key.
+        /// </summary>
+        /// <param name="expectedTerm">the term expected to occur in at least 1 Param in the given collection</param>
+        /// <param name="paramCollection">The param collection to validate</param>
+        static member ContainsNonKeyParamWithTerm (expectedTerm : CvTerm) (paramCollection: #seq<#IParam>) =            
+            match Seq.exists (fun e -> Param.getTerm e = expectedTerm && e.Value <> ParamValue.CvValue ARCTokenization.Terms.StructuralTerms.metadataSectionKey) paramCollection with
+            | true  -> ()
+            | false ->
+                expectedTerm
+                |> ErrorMessage.ofCvTerm $"value does not exist"
+                |> Expecto.Tests.failtestNoStackf "%s"
+
+        /// <summary>
         /// Validates if the given Param is contained in the given collection át least once.
         /// </summary>
         /// <param name="expectedParam">the param expected to occur at least once in the given collection</param>

--- a/tests/ARCExpect.Tests/ARCExpectTests.fs
+++ b/tests/ARCExpect.Tests/ARCExpectTests.fs
@@ -82,6 +82,15 @@ let ``Validate.ParamCollection API tests`` =
                     (fun () -> Validate.ParamCollection.ContainsParamWithTerm ReferenceObjects.CvTerms.``Investigation Person First Name`` [ReferenceObjects.CvParams.``Investigation Person Email (valid)``] ) 
                     "non-contained cvparam was not correctly detected as not contained"
             }
+            test "ContainsNonKeyParamWithTerm passes if valid" {
+                let metadataSectionKeyParam = ReferenceObjects.CvParams.``Investigation Description Section Key``
+                let metadataParam = ReferenceObjects.CvParams.``Investigation Description``
+                Validate.ParamCollection.ContainsNonKeyParamWithTerm ReferenceObjects.CvTerms.``Investigation Description`` [metadataSectionKeyParam; metadataParam] }
+            test "ContainsNonKeyParamWithTerm fails if only metadata section key" {
+                Expect.throws 
+                    (fun () -> Validate.ParamCollection.ContainsNonKeyParamWithTerm ReferenceObjects.CvTerms.``Investigation Description`` [ReferenceObjects.CvParams.``Investigation Description Section Key``] ) 
+                    "Only metadata section key was present"
+            }
             test "SatisfiesPredicate passes if valid" {Validate.ParamCollection.SatisfiesPredicate (fun x -> x|>List.exists(fun y -> y.Name = ReferenceObjects.CvTerms.``Investigation Person First Name``.Name)) [ReferenceObjects.CvParams.``Investigation Person First Name``] }
             test "SatisfiesPredicate fails if invalid" {
                 Expect.throws 

--- a/tests/ARCExpect.Tests/ReferenceObjects.fs
+++ b/tests/ARCExpect.Tests/ReferenceObjects.fs
@@ -15,7 +15,9 @@ module CvTerms =
 
     let ``Investigation Person First Name`` = CvTerm.create("INVMSO:00000023","Investigation Person First Name","INVMSO")
 
-    let ``Investigation Person Email`` = CvTerm.create("INVMSO:00000025","Investigation Person Email","INVMSO")        
+    let ``Investigation Person Email`` = CvTerm.create("INVMSO:00000025","Investigation Person Email","INVMSO")
+    
+    let ``Investigation Description`` = CvTerm.create("INVMSO:00000010","Investigation Description","INVMSO")
 
 module CvParams =
     
@@ -26,6 +28,10 @@ module CvParams =
     let ``Investigation Person Email (valid)`` = CvParam(CvTerms.``Investigation Person Email``, ParamValue.Value "yes@yes.com")
 
     let ``Investigation Person Email (invalid)`` = CvParam(CvTerms.``Investigation Person Email``, ParamValue.Value "nope")
+
+    let ``Investigation Description`` = CvParam(CvTerms.``Investigation Description`` , ParamValue.Value "Hello this is a description")
+
+    let ``Investigation Description Section Key`` = CvParam(CvTerms.``Investigation Description`` , ParamValue.CvValue ARCTokenization.Terms.StructuralTerms.metadataSectionKey)
 
 module ValidationResult =
     


### PR DESCRIPTION
function to be used to fix https://github.com/nfdi4plants/arc-validate-package-registry/issues/56

The problem there is the existence of of the metadata section key being enough to make all tests pass. Instead, the existence of an actual non-section key value has to be checked.