### PR TITLE
Fix specification failing for multiple workflow files per workflow

### DIFF
--- a/src/ARCExpect/SpecificationValidation/V2_0_0_Draft.fs
+++ b/src/ARCExpect/SpecificationValidation/V2_0_0_Draft.fs
@@ -380,8 +380,8 @@ module V2_0_0_Draft =
                                 | _ -> false
                         )
                     
-                    cwls
-                    |> Validate.ParamCollection.SatisfiesPredicate (fun x -> (Seq.length x) = (workflowDir|>Seq.length)) 
+                    //cwls
+                    //|> Validate.ParamCollection.SatisfiesPredicate (fun x -> (Seq.length x) = (workflowDir|>Seq.length)) 
                     
                     cwls
                     |> Validate.ParamCollection.SatisfiesPredicate(fun x -> 


### PR DESCRIPTION
This is a hotfix, stopping the validation from failing if a workflow folder contains multiple cwl files (which is allowed).

IMO, in the long term, the validation should check each folder individually. 