### PR TITLE
New ORCID pattern and fixed package tests

### DIFF
--- a/src/ARCExpect/StringValidationPattern.fs
+++ b/src/ARCExpect/StringValidationPattern.fs
@@ -6,9 +6,9 @@ module StringValidationPattern =
     open System
     open System.Text.RegularExpressions
     open FSharpAux
-    
+
     let email = Regex(@"^[^@\s]+@[^@\s]+\.[^@\s]+$")
-    let orcid = Regex(@"^\d{4}-\d{4}-\d{4}-\d{3}[0-9X]$")
+    let orcid = Regex(@"^(https?://(www.)?orcid.org/)?(?<orcid>\d{4}-\d{4}-\d{4}-\d{3}[0-9X])/?$")
 
     /// Creates a Regex that matches for the given lower and upper character limit. Input may be None if there shall be no upper or lower limit.
     let characterLimit (lowerLimit : int option) (upperLimit : int option) =
@@ -50,7 +50,9 @@ module StringValidationPattern =
         /// Checks if a given string is a valid ORCID.
         /// 
         /// Checks if the ORCID is in current number range and has a valid checksum digit.
-        let checkValid (input : string) =            
-            let isNum = orcid.Match(input).Success
-            let noHyphens = String.replace "-" "" input
-            isNum && checkRange noHyphens && checksum noHyphens = noHyphens[noHyphens.Length - 1]
+        let checkValid (input : string) =
+            let isOrcid = orcid.Match(input).Success
+            let onlyNumber = 
+                orcid.Match(input).Groups["orcid"].Value
+                |> String.replace "-" ""
+            isOrcid && checkRange onlyNumber && checksum onlyNumber = onlyNumber[onlyNumber.Length - 1]

--- a/tests/ARCExpect.Tests/StringValidationPatternTests.fs
+++ b/tests/ARCExpect.Tests/StringValidationPatternTests.fs
@@ -16,6 +16,14 @@ let dummyOrcidSumRight = "0123-4567-8910-1111"
 let dummyOrcidWrong = "1111-2222-3333-4444"
 let dummyOrcidTotallyWrong = "abcd-efgh-ijkl-mnox"
 let dummyOrcidRight = "0000-0001-5874-2232"
+let dummyOrcidUrl1 = "http://orcid.org/0000-0001-5874-2232"
+let dummyOrcidUrl2 = "http://orcid.org/0000-0001-5874-2232/"
+let dummyOrcidUrl3 = "http://www.orcid.org/0000-0001-5874-2232"
+let dummyOrcidUrl4 = "http://www.orcid.org/0000-0001-5874-2232/"
+let dummyOrcidUrl5 = "https://orcid.org/0000-0001-5874-2232"
+let dummyOrcidUrl6 = "https://orcid.org/0000-0001-5874-2232/"
+let dummyOrcidUrl7 = "https://www.orcid.org/0000-0001-5874-2232"
+let dummyOrcidUrl8 = "https://www.orcid.org/0000-0001-5874-2232/"
 
 let dummyString1 = "asd"
 let dummyString2 = "asdasdasdasdasdasdasdasdasdasd"
@@ -51,6 +59,14 @@ let ``StringValidationPattern tests`` =
             testList "checkValid" [
                 testCase "Is valid" <| fun _ ->
                     Expect.isTrue (checkValid dummyOrcidRight) "ORCID is invalid"
+                    Expect.isTrue (checkValid dummyOrcidUrl1) "ORCID URL 1 is invalid"
+                    Expect.isTrue (checkValid dummyOrcidUrl2) "ORCID URL 2 is invalid"
+                    Expect.isTrue (checkValid dummyOrcidUrl3) "ORCID URL 3 is invalid"
+                    Expect.isTrue (checkValid dummyOrcidUrl4) "ORCID URL 4 is invalid"
+                    Expect.isTrue (checkValid dummyOrcidUrl5) "ORCID URL 5 is invalid"
+                    Expect.isTrue (checkValid dummyOrcidUrl6) "ORCID URL 6 is invalid"
+                    Expect.isTrue (checkValid dummyOrcidUrl7) "ORCID URL 7 is invalid"
+                    Expect.isTrue (checkValid dummyOrcidUrl8) "ORCID URL 8 is invalid"
                 testCase "Is invalid" <| fun _ ->
                     Expect.isFalse (checkValid dummyOrcidWrong) "ORCID is valid (though it mustn't)"
                 testCase "Is totally invalid" <| fun _ ->

--- a/tests/arc-validate.Tests/CLITests/ValidateCommandTests.fs
+++ b/tests/arc-validate.Tests/CLITests/ValidateCommandTests.fs
@@ -392,11 +392,11 @@ let ``ValidateCommand CLI Tests`` =
                         "Install: Exit code is 0" , 
                             fun tool args proc -> Expect.equal proc.ExitCode 0 (ErrorMessage.withProcessDiagnostics "incorrect exit code" proc tool args )
                         "Install: Console output indicates that the package was installed" , 
-                            fun tool args proc -> Expect.stringContains proc.Result.Output "installed package test@5.0.0.fsx at" (ErrorMessage.withProcessDiagnostics "incorrect console output" proc tool args )
+                            fun tool args proc -> Expect.stringContains proc.Result.Output "installed package test@6.0.2.fsx at" (ErrorMessage.withProcessDiagnostics "incorrect console output" proc tool args )
                         "Install: Package script exists in avpr cache after running package install test" ,  
-                            fun tool args proc -> Expect.isTrue (File.Exists(Path.Combine(expected_package_cache_folder_path_release, "test@5.0.0.fsx")))  (ErrorMessage.withCLIDiagnostics "package file was not installed at expected location" tool args )
+                            fun tool args proc -> Expect.isTrue (File.Exists(Path.Combine(expected_package_cache_folder_path_release, "test@6.0.2.fsx")))  (ErrorMessage.withCLIDiagnostics "package file was not installed at expected location" tool args )
                         "Install: Package script does not exist in preview cache after running package install test" ,  
-                            fun tool args proc -> Expect.isFalse (File.Exists(Path.Combine(expected_package_cache_folder_path_preview, "test@5.0.0.fsx")))  (ErrorMessage.withCLIDiagnostics "package file was not installed at expected location" tool args )
+                            fun tool args proc -> Expect.isFalse (File.Exists(Path.Combine(expected_package_cache_folder_path_preview, "test@6.0.2.fsx")))  (ErrorMessage.withCLIDiagnostics "package file was not installed at expected location" tool args )
                 
                     ]
                 yield! 
@@ -411,7 +411,7 @@ let ``ValidateCommand CLI Tests`` =
                         "Validate: Console output does not indicate that package is not installed" , 
                             fun tool args proc -> Expect.isFalse (proc.Result.Output.Contains("Package test not installed. You can run run arc-validate package install ")) (ErrorMessage.withProcessDiagnostics "incorrect console output" proc tool args )
                         "Validate: Console Output is correct" ,
-                            fun tool args proc -> Expect.isTrue (proc.Result.Output.Contains("If you can read this in your console, you successfully executed test package v5.0.0!")) (ErrorMessage.withProcessDiagnostics "incorrect console output" proc tool args )
+                            fun tool args proc -> Expect.isTrue (proc.Result.Output.Contains("If you can read this in your console, you successfully executed test package v6.0.1!")) (ErrorMessage.withProcessDiagnostics "incorrect console output" proc tool args )
                         ]
                 ])
         ])


### PR DESCRIPTION
This PR
- updates the Regex pattern for ORCIDs to include URLs
  - updates the respective unit test
- fixes some package-related tests where the latest package was not updated in the test's code
- closes #224 