### PR TITLE
No tests when packing

### DIFF
--- a/build/PackageTasks.fs
+++ b/build/PackageTasks.fs
@@ -12,7 +12,7 @@ open Fake.DotNet
 open Fake.IO.Globbing.Operators
 
 
-let pack = BuildTask.create "Pack" [ clean; build; runTests ] {
+let pack = BuildTask.create "Pack" [ clean; build ] {
     [
         CoreProject
         ValidationPackagesProject
@@ -68,7 +68,6 @@ let packPrerelease =
         [
             clean
             build
-            runTests
         ] {
         [
             CoreProject

--- a/build/ReleaseTasks.fs
+++ b/build/ReleaseTasks.fs
@@ -17,7 +17,7 @@ open Fake.IO.Globbing.Operators
 
 
 let createTag =
-    BuildTask.create "CreateTag" [ clean; build; runTests; pack ] {
+    BuildTask.create "CreateTag" [ clean; build; pack ] {
         if promptYesNo (sprintf "tagging branch with %s OK?" branchTag) then
             Git.Branches.tag "" branchTag
             Git.Branches.pushTag "" projectRepo branchTag
@@ -44,7 +44,7 @@ let createPrereleaseTag =
 
 
 let publishNuget =
-    BuildTask.create "PublishNuget" [ clean; build; runTests; pack ] {
+    BuildTask.create "PublishNuget" [ clean; build; pack ] {
         let targets =
             (!!(sprintf "%s/*.*pkg" pkgDir))
 
@@ -83,7 +83,6 @@ let publishNugetPrerelease =
         [
             clean
             build
-            runTests
             packPrerelease
         ] {
         let targets =


### PR DESCRIPTION
This PR
- changes some build tasks so that they don't use `runtests` task anymore due to limit exceeding when downloading from GitHub
- closes #229 